### PR TITLE
Localize subagent control copy

### DIFF
--- a/src/extension/register.ts
+++ b/src/extension/register.ts
@@ -34,10 +34,12 @@ import { OTLPExporter } from "../observability/exporters/otlp-exporter.ts";
 import { HeartbeatWatcher } from "../runtime/heartbeat-watcher.ts";
 import { appendDeadletter } from "../runtime/deadletter.ts";
 import { detectInterruptedRuns } from "../runtime/crash-recovery.ts";
+import { initI18n } from "../i18n.ts";
 
 export { __test__subagentSpawnParams };
 
 export function registerPiTeams(pi: ExtensionAPI): void {
+	const disposeI18n = initI18n(pi);
 	resetTimings();
 	time("register:start");
 	const globalStore = globalThis as Record<string, unknown>;
@@ -337,6 +339,7 @@ export function registerPiTeams(pi: ExtensionAPI): void {
 		notificationSink = undefined;
 		rpcHandle?.unsubscribe();
 		rpcHandle = undefined;
+		disposeI18n();
 		sessionGeneration += 1;
 		currentCtx = undefined;
 		if (globalStore[runtimeCleanupStoreKey] === cleanupRuntime) delete globalStore[runtimeCleanupStoreKey];

--- a/src/extension/registration/subagent-tools.ts
+++ b/src/extension/registration/subagent-tools.ts
@@ -7,6 +7,7 @@ import { readPersistedSubagentRecord, savePersistedSubagentRecord, type Subagent
 import { loadConfig } from "../../config/config.ts";
 import { logInternalError } from "../../utils/internal-error.ts";
 import { __test__subagentSpawnParams, formatSubagentRecord, readSubagentRunResult, refreshPersistedSubagentRecord, subagentToolResult } from "./subagent-helpers.ts";
+import { t } from "../../i18n.ts";
 
 export interface SubagentToolRegistrationOptions {
 	ownerSessionGeneration?: () => number;
@@ -37,7 +38,7 @@ export function registerSubagentTools(pi: ExtensionAPI, subagentManager: Subagen
 			if (!permission.allowed) return subagentToolResult(permission.reason ?? "Current role cannot spawn subagents.", { role: currentRole, mode: permission.mode }, true);
 			const spawnOptions = __test__subagentSpawnParams(params as Record<string, unknown>, ctx);
 			spawnOptions.ownerSessionGeneration = options.ownerSessionGeneration?.();
-			if (!spawnOptions.prompt.trim()) return subagentToolResult("Agent requires prompt.", {}, true);
+			if (!spawnOptions.prompt.trim()) return subagentToolResult(t("agent.requiresPrompt"), {}, true);
 			const runner = async (currentOptions: SubagentSpawnOptions, childSignal?: AbortSignal) => handleTeamTool({ action: "run", agent: currentOptions.type, goal: currentOptions.prompt, model: currentOptions.model, async: currentOptions.background, config: currentOptions.maxTurns ? { runtime: { maxTurns: currentOptions.maxTurns } } : undefined } as TeamToolParamsValue, currentOptions.background ? { ...ctx, signal: childSignal } : { ...ctx, signal: childSignal });
 			const record = subagentManager.spawn(spawnOptions, runner, spawnOptions.background ? undefined : signal);
 			if (spawnOptions.background || record.status === "queued") {
@@ -45,11 +46,11 @@ export function registerSubagentTools(pi: ExtensionAPI, subagentManager: Subagen
 				// Phase 1.6: Record was terminated for telemetry.
 				record.terminated = true;
 				savePersistedSubagentRecord(ctx.cwd, record);
-				return { ...subagentToolResult([`Agent ${record.status === "queued" ? "queued" : "started"}.`, `Agent ID: ${record.id}`, `Type: ${record.type}`, `Description: ${record.description}`, "Use get_subagent_result to retrieve output. Do not duplicate this agent's work."].join("\n"), { agentId: record.id, status: record.status }), terminate: true };
+				return { ...subagentToolResult([t("agent.started", { state: record.status === "queued" ? "queued" : "started" }), t("agent.id", { id: record.id }), t("agent.type", { type: record.type }), t("agent.description", { description: record.description }), t("agent.retrieveHint")].join("\n"), { agentId: record.id, status: record.status }), terminate: true };
 			}
 			await record.promise;
-			const output = readSubagentRunResult(ctx, record) ?? record.result ?? "No output.";
-			const foregroundResult = subagentToolResult([`Agent ${record.id} ${record.status}.`, "", output].join("\n"), { agentId: record.id, runId: record.runId, status: record.status }, record.status === "failed" || record.status === "error");
+			const output = readSubagentRunResult(ctx, record) ?? record.result ?? t("agent.noOutput");
+			const foregroundResult = subagentToolResult([t("agent.foregroundStatus", { id: record.id, status: record.status }), "", output].join("\n"), { agentId: record.id, runId: record.runId, status: record.status }, record.status === "failed" || record.status === "error");
 			if (loadConfig(ctx.cwd).config.tools?.terminateOnForeground === true) {
 				record.terminated = true;
 				savePersistedSubagentRecord(ctx.cwd, record);
@@ -66,14 +67,14 @@ export function registerSubagentTools(pi: ExtensionAPI, subagentManager: Subagen
 		parameters: Type.Object({ agent_id: Type.String({ description: "Agent ID returned by Agent." }), wait: Type.Optional(Type.Boolean({ description: "Wait for completion before returning." })), verbose: Type.Optional(Type.Boolean({ description: "Include status metadata before output." })) }) as never,
 		async execute(_id, params, signal, _onUpdate, ctx) {
 			const p = params as { agent_id?: string; wait?: boolean; verbose?: boolean };
-			if (!p.agent_id) return subagentToolResult("get_subagent_result requires agent_id.", {}, true);
+			if (!p.agent_id) return subagentToolResult(t("result.requiresAgentId"), {}, true);
 			const inMemory = subagentManager.getRecord(p.agent_id);
 			const record = inMemory ?? readPersistedSubagentRecord(ctx.cwd, p.agent_id);
-			if (!record) return subagentToolResult(`Agent not found: ${p.agent_id}`, {}, true);
+			if (!record) return subagentToolResult(t("result.notFound", { id: p.agent_id }), {}, true);
 			let current = refreshPersistedSubagentRecord(ctx, record);
 			if (inMemory && current !== inMemory) Object.assign(inMemory, current);
 			if (!inMemory && !current.runId && (current.status === "running" || current.status === "queued")) {
-				current = { ...current, status: "error", error: "Subagent was interrupted before its durable run id was recorded; it cannot be recovered after restart.", completedAt: current.completedAt ?? Date.now() };
+				current = { ...current, status: "error", error: t("result.unrecoverable"), completedAt: current.completedAt ?? Date.now() };
 				savePersistedSubagentRecord(ctx.cwd, current);
 			}
 			if (p.wait && (current.status === "running" || current.status === "queued")) {
@@ -86,7 +87,7 @@ export function registerSubagentTools(pi: ExtensionAPI, subagentManager: Subagen
 				}
 				else while (current.status === "running" || current.status === "queued") {
 					if (signal?.aborted) {
-						current = { ...current, status: "error", error: "Waiting for subagent result was aborted.", completedAt: Date.now() };
+						current = { ...current, status: "error", error: t("result.waitAborted"), completedAt: Date.now() };
 						savePersistedSubagentRecord(ctx.cwd, current);
 						break;
 					}
@@ -101,7 +102,7 @@ export function registerSubagentTools(pi: ExtensionAPI, subagentManager: Subagen
 				if (inMemory) inMemory.resultConsumed = true;
 				savePersistedSubagentRecord(ctx.cwd, current);
 			}
-			const text = [p.verbose ? formatSubagentRecord(current) : undefined, output ? `${p.verbose ? "\n" : ""}${output}` : current.status === "running" || current.status === "queued" ? "Agent is still running. Use wait=true or check again later." : current.error ?? "No output."].filter((line): line is string => Boolean(line)).join("\n");
+			const text = [p.verbose ? formatSubagentRecord(current) : undefined, output ? `${p.verbose ? "\n" : ""}${output}` : current.status === "running" || current.status === "queued" ? t("result.stillRunning") : current.error ?? t("agent.noOutput")].filter((line): line is string => Boolean(line)).join("\n");
 			return subagentToolResult(text, { agentId: current.id, runId: current.runId, status: current.status }, current.status === "failed" || current.status === "error");
 		},
 	};
@@ -114,8 +115,8 @@ export function registerSubagentTools(pi: ExtensionAPI, subagentManager: Subagen
 		async execute(_id, params, _signal, _onUpdate, ctx) {
 			const p = params as { agent_id?: string; message?: string };
 			const record = p.agent_id ? subagentManager.getRecord(p.agent_id) ?? readPersistedSubagentRecord(ctx.cwd, p.agent_id) : undefined;
-			if (!record) return subagentToolResult(`Agent not found: ${p.agent_id ?? ""}`, {}, true);
-			return subagentToolResult([`Steering request noted for ${record.id}.`, "Current default pi-crew backend is child-process, so mid-turn session.steer is not available yet.", record.runId ? `Use team cancel runId=${record.runId} if the agent must be interrupted.` : undefined].filter((line): line is string => Boolean(line)).join("\n"), { agentId: record.id, runId: record.runId, status: record.status });
+			if (!record) return subagentToolResult(t("result.notFound", { id: p.agent_id ?? "" }), {}, true);
+			return subagentToolResult([t("steer.noted", { id: record.id }), t("steer.unavailable"), record.runId ? t("steer.cancelHint", { runId: record.runId }) : undefined].filter((line): line is string => Boolean(line)).join("\n"), { agentId: record.id, runId: record.runId, status: record.status });
 		},
 	};
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,107 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+type Locale = "es" | "fr" | "pt-BR";
+type Params = Record<string, string | number>;
+
+const namespace = "pi-crew";
+
+const fallback = {
+	"agent.requiresPrompt": "Agent requires prompt.",
+	"agent.started": "Agent {state}.",
+	"agent.id": "Agent ID: {id}",
+	"agent.type": "Type: {type}",
+	"agent.description": "Description: {description}",
+	"agent.retrieveHint": "Use get_subagent_result to retrieve output. Do not duplicate this agent's work.",
+	"agent.foregroundStatus": "Agent {id} {status}.",
+	"agent.noOutput": "No output.",
+	"result.requiresAgentId": "get_subagent_result requires agent_id.",
+	"result.notFound": "Agent not found: {id}",
+	"result.unrecoverable": "Subagent was interrupted before its durable run id was recorded; it cannot be recovered after restart.",
+	"result.waitAborted": "Waiting for subagent result was aborted.",
+	"result.stillRunning": "Agent is still running. Use wait=true or check again later.",
+	"steer.noted": "Steering request noted for {id}.",
+	"steer.unavailable": "Current default pi-crew backend is child-process, so mid-turn session.steer is not available yet.",
+	"steer.cancelHint": "Use team cancel runId={runId} if the agent must be interrupted.",
+} as const;
+
+type Key = keyof typeof fallback;
+
+const translations: Record<Locale, Partial<Record<Key, string>>> = {
+	es: {
+		"agent.requiresPrompt": "Agent requiere prompt.",
+		"agent.started": "Agent {state}.",
+		"agent.id": "ID del agente: {id}",
+		"agent.type": "Tipo: {type}",
+		"agent.description": "Descripción: {description}",
+		"agent.retrieveHint": "Usa get_subagent_result para recuperar la salida. No dupliques el trabajo de este agente.",
+		"agent.foregroundStatus": "Agent {id} {status}.",
+		"agent.noOutput": "Sin salida.",
+		"result.requiresAgentId": "get_subagent_result requiere agent_id.",
+		"result.notFound": "Agente no encontrado: {id}",
+		"result.unrecoverable": "El subagente fue interrumpido antes de registrar su ID de ejecución duradero; no se puede recuperar tras reiniciar.",
+		"result.waitAborted": "Se canceló la espera del resultado del subagente.",
+		"result.stillRunning": "El agente sigue ejecutándose. Usa wait=true o vuelve a comprobar más tarde.",
+		"steer.noted": "Solicitud de dirección registrada para {id}.",
+		"steer.unavailable": "El backend predeterminado actual de pi-crew es child-process, así que session.steer a mitad de turno aún no está disponible.",
+		"steer.cancelHint": "Usa team cancel runId={runId} si hay que interrumpir el agente.",
+	},
+	fr: {
+		"agent.requiresPrompt": "Agent nécessite un prompt.",
+		"agent.started": "Agent {state}.",
+		"agent.id": "ID de l’agent : {id}",
+		"agent.type": "Type : {type}",
+		"agent.description": "Description : {description}",
+		"agent.retrieveHint": "Utilisez get_subagent_result pour récupérer la sortie. Ne dupliquez pas le travail de cet agent.",
+		"agent.foregroundStatus": "Agent {id} {status}.",
+		"agent.noOutput": "Aucune sortie.",
+		"result.requiresAgentId": "get_subagent_result nécessite agent_id.",
+		"result.notFound": "Agent introuvable : {id}",
+		"result.unrecoverable": "Le sous-agent a été interrompu avant l’enregistrement de son ID d’exécution durable ; il ne peut pas être récupéré après redémarrage.",
+		"result.waitAborted": "L’attente du résultat du sous-agent a été annulée.",
+		"result.stillRunning": "L’agent est toujours en cours d’exécution. Utilisez wait=true ou réessayez plus tard.",
+		"steer.noted": "Demande de pilotage enregistrée pour {id}.",
+		"steer.unavailable": "Le backend pi-crew par défaut actuel est child-process, donc session.steer en milieu de tour n’est pas encore disponible.",
+		"steer.cancelHint": "Utilisez team cancel runId={runId} si l’agent doit être interrompu.",
+	},
+	"pt-BR": {
+		"agent.requiresPrompt": "Agent requer prompt.",
+		"agent.started": "Agent {state}.",
+		"agent.id": "ID do agente: {id}",
+		"agent.type": "Tipo: {type}",
+		"agent.description": "Descrição: {description}",
+		"agent.retrieveHint": "Use get_subagent_result para recuperar a saída. Não duplique o trabalho deste agente.",
+		"agent.foregroundStatus": "Agent {id} {status}.",
+		"agent.noOutput": "Sem saída.",
+		"result.requiresAgentId": "get_subagent_result requer agent_id.",
+		"result.notFound": "Agente não encontrado: {id}",
+		"result.unrecoverable": "O subagente foi interrompido antes que seu ID de execução durável fosse registrado; ele não pode ser recuperado após reiniciar.",
+		"result.waitAborted": "A espera pelo resultado do subagente foi abortada.",
+		"result.stillRunning": "O agente ainda está em execução. Use wait=true ou verifique novamente mais tarde.",
+		"steer.noted": "Solicitação de orientação registrada para {id}.",
+		"steer.unavailable": "O backend padrão atual do pi-crew é child-process, então session.steer no meio do turno ainda não está disponível.",
+		"steer.cancelHint": "Use team cancel runId={runId} se o agente precisar ser interrompido.",
+	},
+};
+
+let currentLocale: string | undefined;
+
+function format(template: string, params: Params = {}): string {
+	return template.replace(/\{(\w+)\}/g, (_match, key) => String(params[key] ?? `{${key}}`));
+}
+
+export function t(key: Key, params?: Params): string {
+	const locale = currentLocale as Locale | undefined;
+	const template = locale ? translations[locale]?.[key] : undefined;
+	return format(template ?? fallback[key], params);
+}
+
+export function initI18n(pi: ExtensionAPI): () => void {
+	pi.events?.emit?.("pi-core/i18n/registerBundle", { namespace, defaultLocale: "en", fallback, translations });
+	const unsubscribe = pi.events?.on?.("pi-core/i18n/localeChanged", (event: unknown) => {
+		currentLocale = event && typeof event === "object" && "locale" in event ? String((event as { locale?: unknown }).locale ?? "") : undefined;
+	});
+	pi.events?.emit?.("pi-core/i18n/requestApi", { namespace, onApi(api: { getLocale?: () => string | undefined }) { currentLocale = api.getLocale?.(); } });
+	return () => {
+		unsubscribe?.();
+	};
+}


### PR DESCRIPTION
This keeps pi-crew English by default, but makes the subagent control path optionally localizable.

Why this slice:
- `Agent`, `get_subagent_result`, and `steer_subagent` return operational messages that affect whether a user waits, joins a background result, retries, or cancels an agent.
- I kept this to subagent control/result copy only; no README changes and no broad UI sweep.

What changed:
- adds a small optional i18n bridge with English fallbacks
- adds es/fr/pt-BR bundles for Agent launch/result/steer messages
- registers the bundle without adding a dependency
- disposes the locale listener during `session_shutdown`, so the existing lifecycle subscription test stays clean
- preserves current behavior when no i18n provider is present

Validation:
- `npx tsc --noEmit` passed
- targeted Node 24 tests passed: `register-observability-lifecycle`, `subagent-tool-params`, `subagent-tools-integration` (12/12)
- full unit suite on Node 24 found one lifecycle listener leak before the fix; the targeted lifecycle rerun passed after the fix
- `npm pack --dry-run` passed
- `npm run typecheck` is blocked on my local Node 20 because this repo's script requires `node --experimental-strip-types`, which is not available there

The changes are isolated to `src/i18n.ts`, registration cleanup, and subagent tool output, so they should be easy to revert if you do not want localization in this path.