### PR TITLE
fix: avoid implicit live-session in auto mode and persist live heartbeat

### DIFF
--- a/src/runtime/heartbeat-watcher.ts
+++ b/src/runtime/heartbeat-watcher.ts
@@ -3,10 +3,11 @@ import type { NotificationDescriptor } from "../extension/notification-router.ts
 import type { MetricRegistry } from "../observability/metric-registry.ts";
 import { appendEvent } from "../state/event-log.ts";
 import { loadRunManifestById } from "../state/state-store.ts";
-import type { TeamRunManifest } from "../state/types.ts";
+import type { TeamRunManifest, TeamTaskState } from "../state/types.ts";
 import { logInternalError } from "../utils/internal-error.ts";
 import type { ManifestCache } from "./manifest-cache.ts";
 import { classifyHeartbeat, DEFAULT_GRADIENT_THRESHOLDS, heartbeatAgeMs, type GradientThresholds, type HeartbeatLevel } from "./heartbeat-gradient.ts";
+import type { WorkerHeartbeatState } from "./worker-heartbeat.ts";
 
 export interface HeartbeatWatcherRouter {
 	enqueue(notification: NotificationDescriptor): boolean;
@@ -29,6 +30,24 @@ export interface HeartbeatWatcherOptions {
 	deadletterCooldownMs?: number;
 	onDead?: (runId: string, taskId: string, elapsed: number) => void;
 	onDeadletterTrigger?: (manifest: TeamRunManifest, taskId: string) => void;
+}
+
+function effectiveHeartbeat(task: TeamTaskState): WorkerHeartbeatState | undefined {
+	if (task.heartbeat?.alive === false) return task.heartbeat;
+	const heartbeatAt = task.heartbeat?.lastSeenAt ? Date.parse(task.heartbeat.lastSeenAt) : Number.NaN;
+	const progressAt = task.agentProgress?.lastActivityAt ? Date.parse(task.agentProgress.lastActivityAt) : Number.NaN;
+	if (Number.isFinite(progressAt) && (!Number.isFinite(heartbeatAt) || progressAt > heartbeatAt)) {
+		return {
+			workerId: task.heartbeat?.workerId ?? task.id,
+			pid: task.heartbeat?.pid,
+			lastSeenAt: new Date(progressAt).toISOString(),
+			lastStdoutAt: task.heartbeat?.lastStdoutAt,
+			lastEventAt: task.heartbeat?.lastEventAt,
+			turnCount: task.heartbeat?.turnCount,
+			alive: task.heartbeat?.alive ?? true,
+		};
+	}
+	return task.heartbeat;
 }
 
 /**
@@ -96,8 +115,14 @@ export class HeartbeatWatcher {
 				activeKeys.add(key);
 				this.lastSeen.set(key, now);
 
-				const elapsed = heartbeatAgeMs(task.heartbeat, now);
-				const level = classifyHeartbeat(task.heartbeat, thresholds, now);
+				const heartbeat = effectiveHeartbeat(task);
+				const elapsed = heartbeatAgeMs(heartbeat, now);
+				const level = classifyHeartbeat(heartbeat, thresholds, now);
+				const heartbeatAt = task.heartbeat?.lastSeenAt ? Date.parse(task.heartbeat.lastSeenAt) : Number.NaN;
+				const progressAt = task.agentProgress?.lastActivityAt ? Date.parse(task.agentProgress.lastActivityAt) : Number.NaN;
+				if (Number.isFinite(progressAt) && (!Number.isFinite(heartbeatAt) || progressAt > heartbeatAt)) {
+					this.opts.registry.counter("crew.heartbeat.progress_fallback_total", "Heartbeat classifications that used task progress fallback evidence").inc({ runId: run.runId });
+				}
 				this.opts.registry.gauge("crew.heartbeat.staleness_ms", "Heartbeat elapsed since last seen, milliseconds").set({ runId: run.runId, taskId: task.id }, Number.isFinite(elapsed) ? elapsed : thresholds.deadMs);
 				this.opts.registry.counter("crew.heartbeat.level_total", "Heartbeat classifications by level").inc({ runId: run.runId, level });
 				const previous = this.lastLevel.get(key);

--- a/src/runtime/runtime-resolver.ts
+++ b/src/runtime/runtime-resolver.ts
@@ -71,7 +71,8 @@ export async function resolveCrewRuntime(config: PiTeamsConfig, env: NodeJS.Proc
 	if (requestedMode === "child-process") return childCaps(requestedMode);
 	// When a child-process mock is active (tests), force auto-mode to child-process where the mock is active.
 	if (requestedMode === "auto" && env.PI_TEAMS_MOCK_CHILD_PI) return childCaps(requestedMode, "PI_TEAMS_MOCK_CHILD_PI mock forces child-process runtime in auto mode.");
-	if (requestedMode === "live-session" || requestedMode === "auto") {
+	const preferLiveSession = requestedMode === "live-session" || (requestedMode === "auto" && config.runtime?.preferLiveSession === true);
+	if (preferLiveSession) {
 		const live = await isLiveSessionRuntimeAvailable(1500, env);
 		if (live.available) return liveCaps(requestedMode);
 		if (requestedMode === "live-session" && config.runtime?.allowChildProcessFallback === false)

--- a/src/runtime/task-runner/live-executor.ts
+++ b/src/runtime/task-runner/live-executor.ts
@@ -8,8 +8,10 @@ import type { ArtifactDescriptor, TeamRunManifest, TeamTaskState } from "../../s
 import type { WorkflowStep } from "../../workflows/workflow-config.ts";
 import { appendCrewAgentEvent, appendCrewAgentOutput, emptyCrewAgentProgress, recordFromTask, upsertCrewAgent } from "../crew-agent-records.ts";
 import { createStartupEvidence, type WorkerStartupEvidence } from "../worker-startup.ts";
+import { createWorkerHeartbeat, touchWorkerHeartbeat } from "../worker-heartbeat.ts";
 import { runLiveSessionTask } from "../live-session-runtime.ts";
 import { shouldAppendProgressEventUpdate, type ProgressEventSummary } from "../progress-event-coalescer.ts";
+import { persistSingleTaskUpdate } from "./state-helpers.ts";
 import { applyAgentProgressEvent, applyUsageToProgress, progressEventSummary, shouldFlushProgressEvent } from "./progress.ts";
 import type { ParsedPiJsonOutput } from "../pi-json-output.ts";
 
@@ -63,11 +65,21 @@ export async function runLiveTask(input: RunLiveTaskInput): Promise<RunLiveTaskO
 		return currentTask ? currentTask.status === "running" : true;
 	});
 	let lastAgentRecordPersistedAt = 0;
+	let lastHeartbeatPersistedAt = 0;
 	let lastRunProgressPersistedAt = 0;
 	let lastRunProgressSummary: ProgressEventSummary | undefined;
+	const persistLiveHeartbeat = (force = false): void => {
+		if (!isCurrent()) return;
+		const now = Date.now();
+		if (!force && now - lastHeartbeatPersistedAt < 1000) return;
+		lastHeartbeatPersistedAt = now;
+		task = { ...task, heartbeat: touchWorkerHeartbeat(task.heartbeat ?? createWorkerHeartbeat(task.id)) };
+		tasks = persistSingleTaskUpdate(manifest, tasks, task);
+	};
 	const persistLiveProgress = (event: unknown, force = false): void => {
 		if (!isCurrent()) return;
 		const now = Date.now();
+		persistLiveHeartbeat(force);
 		if (force || shouldFlushProgressEvent(event) || now - lastAgentRecordPersistedAt >= 500) {
 			upsertCrewAgent(manifest, recordFromTask(manifest, task, "live-session"));
 			lastAgentRecordPersistedAt = now;
@@ -88,36 +100,45 @@ export async function runLiveTask(input: RunLiveTaskInput): Promise<RunLiveTaskO
 		(!input.runtimeConfig?.maxTurns || agentMax < input.runtimeConfig.maxTurns))
 		? { ...input.runtimeConfig, maxTurns: agentMax }
 		: input.runtimeConfig;
-	const liveResult = await runLiveSessionTask({
-		manifest,
-		task,
-		step,
-		agent,
-		prompt,
-		signal: input.signal,
-		transcriptPath,
-		runtimeConfig: effectiveRuntimeConfig,
-		parentContext: input.parentContext,
-		parentModel: input.parentModel,
-		modelRegistry: input.modelRegistry,
-		modelOverride: input.modelOverride,
-		teamRoleModel: input.teamRoleModel,
-		isCurrent,
-		workspaceId: input.workspaceId,
-		// Phase 2: Pass output schema for yield validation
-		outputSchema: undefined,
-		onOutput: (text) => {
-			if (!isCurrent()) return;
-			appendCrewAgentOutput(manifest, task.id, text);
-		},
-		onEvent: (event) => {
-			if (!isCurrent()) return;
-			appendCrewAgentEvent(manifest, task.id, event);
-			task = { ...task, agentProgress: applyAgentProgressEvent(task.agentProgress ?? emptyCrewAgentProgress(), event, task.startedAt) };
-			tasks = updateTask(tasks, task);
-			persistLiveProgress(event);
-		},
-	});
+	const liveHeartbeatTimer = setInterval(() => {
+		persistLiveHeartbeat();
+	}, 1000);
+	liveHeartbeatTimer.unref();
+	let liveResult;
+	try {
+		liveResult = await runLiveSessionTask({
+			manifest,
+			task,
+			step,
+			agent,
+			prompt,
+			signal: input.signal,
+			transcriptPath,
+			runtimeConfig: effectiveRuntimeConfig,
+			parentContext: input.parentContext,
+			parentModel: input.parentModel,
+			modelRegistry: input.modelRegistry,
+			modelOverride: input.modelOverride,
+			teamRoleModel: input.teamRoleModel,
+			isCurrent,
+			workspaceId: input.workspaceId,
+			// Phase 2: Pass output schema for yield validation
+			outputSchema: undefined,
+			onOutput: (text) => {
+				if (!isCurrent()) return;
+				appendCrewAgentOutput(manifest, task.id, text);
+			},
+			onEvent: (event) => {
+				if (!isCurrent()) return;
+				appendCrewAgentEvent(manifest, task.id, event);
+				task = { ...task, agentProgress: applyAgentProgressEvent(task.agentProgress ?? emptyCrewAgentProgress(), event, task.startedAt) };
+				tasks = updateTask(tasks, task);
+				persistLiveProgress(event);
+			},
+		});
+	} finally {
+		clearInterval(liveHeartbeatTimer);
+	}
 	const startupEvidence = createStartupEvidence({ command: "live-session", startedAt: attemptStartedAt, finishedAt: new Date(), promptSentAt: attemptStartedAt, promptAccepted: liveResult.exitCode === 0 && !liveResult.error, stderr: liveResult.stderr, error: liveResult.error, exitCode: liveResult.exitCode });
 	const exitCode = liveResult.exitCode;
 	const error = liveResult.error || (liveResult.exitCode && liveResult.exitCode !== 0 ? liveResult.stderr || `Live session exited with ${liveResult.exitCode}` : undefined);


### PR DESCRIPTION
Closes #5

## Summary
This PR fixes two related runtime issues in pi-crew:

1. `runtime.mode = "auto"` was implicitly preferring `live-session`, which routed ordinary runs into an unstable path unexpectedly.
2. Live-session activity was not durably advancing task heartbeat state in `tasks.json`, which could lead to false `heartbeat_dead` reports.

## Changes
- `src/runtime/runtime-resolver.ts`
  - `auto` now stays on child-process by default unless `runtime.preferLiveSession === true`
- `src/runtime/task-runner/live-executor.ts`
  - persist live-session heartbeat back to task state
  - keep heartbeat fresh during long silent live-session waits with a lightweight timer
- `src/runtime/heartbeat-watcher.ts`
  - use fresher `agentProgress.lastActivityAt` as fallback heartbeat evidence when newer than persisted heartbeat

## Why
In affected runs, workers could stall after `live-session.prompt_start` with no `prompt_done`/`prompt_error`, and the heartbeat watcher later marked them dead. Separately, heartbeat classification could be stale because live-session progress was reflected in agent progress but not always in persisted task heartbeat state.

## Validation
- reproduced against v0.2.20 behavior locally
- LSP diagnostics clean on patched files
- issue filed as #5

## Notes
This PR intentionally keeps explicit live-session mode available. It only restores documented `auto` behavior and improves live-session heartbeat evidence so normal runs do not get routed into the unstable path by default and active live tasks are less likely to be misclassified as dead.
