### PR TITLE
feat: allow user-configured child env allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Requirements:
 |---------|------|---------|
 | **Runtime** | `mode`: `auto` \| `child-process` \| `scaffold` \| `live-session` | `auto` |
 | | `maxTurns`, `graceTurns`, `groupJoin`, `requirePlanApproval` | various |
+| | `childEnvAllowList` (user config only) | `[]` |
 | **Concurrency** | `limits.maxConcurrentWorkers` | workflow-dependent |
 | | `limits.maxTaskDepth`, `limits.maxChildrenPerTask` | 2, 5 |
 | **Async** | `asyncByDefault` | `false` |
@@ -213,7 +214,7 @@ Requirements:
 | **Observability** | `prometheus.enabled`, `otlp.enabled`, `heartbeatStaleMs` | opt-in |
 | **Worktree** | `worktree.enabled` | disabled by default |
 
-> ⚠️ **Trust boundary**: project config cannot override sensitive execution controls (workers, runtime mode, autonomy, agent overrides). Set those in **user config** only.
+> ⚠️ **Trust boundary**: project config cannot override sensitive execution controls (workers, runtime mode, autonomy, agent overrides, or child env allow-lists). Set those in **user config** only.
 
 📖 Full config reference: [docs/commands-reference.md#team-settings--config-management](docs/commands-reference.md) and [schema.json](schema.json)
 
@@ -351,6 +352,26 @@ Your system prompt here.
 | `PI_TEAMS_MOCK_CHILD_PI=success` | Mock child worker for testing |
 | `PI_TEAMS_PI_BIN=<path>` | Explicit Pi CLI path |
 | `PI_TEAMS_HOME=<path>` | Override home for tests |
+
+Child-process workers receive a sanitized environment by default. The built-in allow-list preserves common model provider variables (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, AWS static credential vars, etc.) and essential runtime variables (`PATH`, `HOME`, `PI_*`).
+
+If your provider uses a non-standard env var (for example a custom provider variable like `CUSTOM_PROVIDER_API_KEY`) or a profile-based credential chain (for example `AWS_PROFILE` for Bedrock SSO), add explicit pass-through entries in **user config**:
+
+```json
+{
+  "runtime": {
+    "childEnvAllowList": [
+      "CUSTOM_PROVIDER_API_KEY",
+      "AWS_PROFILE",
+      "AWS_SESSION_TOKEN",
+      "AWS_CONFIG_FILE",
+      "AWS_SHARED_CREDENTIALS_FILE"
+    ]
+  }
+}
+```
+
+`childEnvAllowList` supports exact names and trailing globs like `MY_PROVIDER_*`. Project config values are ignored so a repository cannot opt child workers into inheriting secrets without user consent.
 
 ---
 

--- a/schema.json
+++ b/schema.json
@@ -72,7 +72,12 @@
         "groupJoinAckTimeoutMs": { "type": "integer", "minimum": 1 },
         "requirePlanApproval": { "type": "boolean" },
         "completionMutationGuard": { "type": "string", "enum": ["off", "warn", "fail"] },
-        "effectivenessGuard": { "type": "string", "enum": ["off", "warn", "block", "fail"] }
+        "effectivenessGuard": { "type": "string", "enum": ["off", "warn", "block", "fail"] },
+        "childEnvAllowList": {
+          "type": "array",
+          "description": "Additional env var names/globs to preserve for child Pi workers. Sensitive: user config only; project config values are ignored.",
+          "items": { "type": "string", "minLength": 1 }
+        }
       }
     },
     "control": {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -181,6 +181,7 @@ function sanitizeProjectConfig(
 			"allowChildProcessFallback",
 			"inheritContext",
 			"isolationPolicy",
+			"childEnvAllowList",
 		] as const) {
 			if (runtime[key] !== undefined) {
 				delete runtime[key];
@@ -742,6 +743,7 @@ function parseRuntimeConfig(value: unknown): CrewRuntimeConfig | undefined {
 			obj.effectivenessGuard,
 		),
 		isolationPolicy: parseIsolationPolicy(obj.isolationPolicy),
+		childEnvAllowList: parseStringList(obj.childEnvAllowList),
 	};
 	return Object.values(runtime).some((entry) => entry !== undefined)
 		? runtime

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -68,6 +68,8 @@ export interface CrewRuntimeConfig {
 		/** Default runtime for roles not in isolatedRoles. Default: "live-session" (uses live-session). */
 		defaultRuntime?: "live-session" | "child-process";
 	};
+	/** Additional environment variable names/globs to pass to child Pi workers. Sensitive: user config only. */
+	childEnvAllowList?: string[];
 	/** Mark certain bash commands as excludeFromContext to reduce context tokens. Default: false */
 	excludeContextBash?: boolean;
 }

--- a/src/runtime/child-pi.ts
+++ b/src/runtime/child-pi.ts
@@ -145,6 +145,8 @@ export interface ChildPiRunInput {
 	maxTurns?: number;
 	/** Extra turns after soft limit before hard abort. Default: 5. */
 	graceTurns?: number;
+	/** Additional env var names/globs to preserve for this child Pi process. */
+	childEnvAllowList?: string[];
 	/** Parent conversation context to inherit when inheritContext is true. */
 	parentContext?: string;
 	/** When true, prepend parentContext to the task prompt. */
@@ -173,7 +175,7 @@ export interface ChildPiRunResult {
 	steered?: boolean;
 }
 
-export function buildChildPiSpawnOptions(cwd: string, env: NodeJS.ProcessEnv): SpawnOptions {
+export function buildChildPiSpawnOptions(cwd: string, env: NodeJS.ProcessEnv, extraAllowList: string[] = []): SpawnOptions {
 	// Filter out env vars whose keys match secret patterns to avoid leaking credentials to child processes.
 	// IMPORTANT: preserve model provider API keys — they are needed by the child Pi to call the LLM.
 	// Also preserve essential non-secret vars (PATH, HOME, USER, etc.) so the child process can function.
@@ -214,6 +216,7 @@ export function buildChildPiSpawnOptions(cwd: string, env: NodeJS.ProcessEnv): S
 			"PI_*",
 			"PI_CREW_*",
 			"PI_TEAMS_*",
+			...extraAllowList,
 		],
 	});
 	// Block execution control vars from leaking to child processes
@@ -415,7 +418,7 @@ export async function runChildPi(input: ChildPiRunInput): Promise<ChildPiRunResu
 	const spawnSpec = getPiSpawnCommand(built.args);
 	try {
 		return await new Promise<ChildPiRunResult>((resolve) => {
-			const child = spawn(spawnSpec.command, spawnSpec.args, buildChildPiSpawnOptions(input.cwd, { ...process.env, ...built.env }));
+			const child = spawn(spawnSpec.command, spawnSpec.args, buildChildPiSpawnOptions(input.cwd, { ...process.env, ...built.env }, input.childEnvAllowList));
 			if (child.pid) {
 				activeChildProcesses.set(child.pid, child);
 				input.onSpawn?.(child.pid);

--- a/src/runtime/task-runner.ts
+++ b/src/runtime/task-runner.ts
@@ -424,6 +424,7 @@ export async function runTeamTask(
 					inheritContext: input.runtimeConfig?.inheritContext,
 					parentContext: input.parentContext,
 					excludeContextBash: input.runtimeConfig?.excludeContextBash,
+					childEnvAllowList: input.runtimeConfig?.childEnvAllowList,
 					sessionId: manifest.sessionId,
 					role: task.role,
 					runId: manifest.runId,

--- a/src/schema/config-schema.ts
+++ b/src/schema/config-schema.ts
@@ -41,6 +41,7 @@ export const PiTeamsRuntimeConfigSchema = Type.Object({
 	requirePlanApproval: Type.Optional(Type.Boolean()),
 	completionMutationGuard: Type.Optional(Type.Union([Type.Literal("off"), Type.Literal("warn"), Type.Literal("fail")])),
 	effectivenessGuard: Type.Optional(Type.Union([Type.Literal("off"), Type.Literal("warn"), Type.Literal("block"), Type.Literal("fail")])),
+	childEnvAllowList: Type.Optional(Type.Array(Type.String({ minLength: 1 }))),
 	isolationPolicy: Type.Optional(Type.Object({
 		isolatedRoles: Type.Optional(Type.Array(Type.String({ minLength: 1 }))),
 		defaultRuntime: Type.Optional(Type.Union([Type.Literal("live-session"), Type.Literal("child-process")])),

--- a/test/integration/phase3-runtime.test.ts
+++ b/test/integration/phase3-runtime.test.ts
@@ -30,6 +30,40 @@ const workflow: WorkflowConfig = {
 	],
 };
 
+test("child Pi spawn options preserve configured extra env vars", () => {
+	const options = buildChildPiSpawnOptions(
+		"/tmp/project",
+		{
+			PATH: process.env.PATH ?? "",
+			CUSTOM_PROVIDER_API_KEY: "provider-secret",
+			AWS_PROFILE: "nsx",
+			UNRELATED_SECRET: "drop-me",
+		},
+		["CUSTOM_PROVIDER_API_KEY", "AWS_PROFILE"],
+	);
+	const env = options.env as Record<string, string>;
+	assert.equal(env.CUSTOM_PROVIDER_API_KEY, "provider-secret");
+	assert.equal(env.AWS_PROFILE, "nsx");
+	assert.equal(env.UNRELATED_SECRET, undefined);
+});
+
+test("child Pi spawn options preserve configured env var globs", () => {
+	const options = buildChildPiSpawnOptions(
+		"/tmp/project",
+		{
+			PATH: process.env.PATH ?? "",
+			MYPROXY_TOKEN: "token-secret",
+			MYPROXY_ENDPOINT: "https://proxy.example",
+			OTHER_TOKEN: "drop-me",
+		},
+		["MYPROXY_*"],
+	);
+	const env = options.env as Record<string, string>;
+	assert.equal(env.MYPROXY_TOKEN, "token-secret");
+	assert.equal(env.MYPROXY_ENDPOINT, "https://proxy.example");
+	assert.equal(env.OTHER_TOKEN, undefined);
+});
+
 test("child Pi spawn options hide Windows console windows", () => {
 	const options = buildChildPiSpawnOptions("/tmp/project", { PATH: process.env.PATH ?? "" });
 	assert.equal(options.windowsHide, true);

--- a/test/unit/project-config.test.ts
+++ b/test/unit/project-config.test.ts
@@ -16,10 +16,10 @@ test("loadConfig merges project config but ignores sensitive project trust-bound
 	try {
 		const userConfig = path.join(tmp, ".pi", "agent", "extensions", "pi-crew", "config.json");
 		fs.mkdirSync(path.dirname(userConfig), { recursive: true });
-		fs.writeFileSync(userConfig, JSON.stringify({ asyncByDefault: true, autonomous: { profile: "suggested", preferAsyncForLongTasks: false }, runtime: { isolationPolicy: { isolatedRoles: ["executor"], defaultRuntime: "child-process" } } }), "utf-8");
+		fs.writeFileSync(userConfig, JSON.stringify({ asyncByDefault: true, autonomous: { profile: "suggested", preferAsyncForLongTasks: false }, runtime: { isolationPolicy: { isolatedRoles: ["executor"], defaultRuntime: "child-process" }, childEnvAllowList: ["CUSTOM_PROVIDER_API_KEY"] } }), "utf-8");
 		const projectConfig = projectConfigPath(tmp);
 		fs.mkdirSync(path.dirname(projectConfig), { recursive: true });
-		fs.writeFileSync(projectConfig, JSON.stringify({ executeWorkers: true, autonomous: { profile: "manual" }, runtime: { isolationPolicy: { isolatedRoles: [], defaultRuntime: "live-session" } } }), "utf-8");
+		fs.writeFileSync(projectConfig, JSON.stringify({ executeWorkers: true, autonomous: { profile: "manual" }, runtime: { isolationPolicy: { isolatedRoles: [], defaultRuntime: "live-session" }, childEnvAllowList: ["PROJECT_SECRET"] } }), "utf-8");
 
 		const loaded = loadConfig(tmp);
 		assert.equal(loaded.config.asyncByDefault, true);
@@ -29,7 +29,9 @@ test("loadConfig merges project config but ignores sensitive project trust-bound
 		assert.ok(loaded.warnings?.some((warning) => warning.includes("autonomous.profile")));
 		assert.equal(loaded.config.autonomous?.preferAsyncForLongTasks, false);
 		assert.deepEqual(loaded.config.runtime?.isolationPolicy, { isolatedRoles: ["executor"], defaultRuntime: "child-process" });
+		assert.deepEqual(loaded.config.runtime?.childEnvAllowList, ["CUSTOM_PROVIDER_API_KEY"]);
 		assert.ok(loaded.warnings?.some((warning) => warning.includes("runtime.isolationPolicy")));
+		assert.ok(loaded.warnings?.some((warning) => warning.includes("runtime.childEnvAllowList")));
 		assert.ok(loaded.paths.includes(projectConfig));
 	} finally {
 		if (oldHome === undefined) delete process.env.HOME;


### PR DESCRIPTION
## Summary

Adds a user-configurable child Pi environment allow-list for child-process workers:

```json
{
  "runtime": {
    "childEnvAllowList": [
      "CUSTOM_PROVIDER_API_KEY",
      "AWS_PROFILE",
      "AWS_SESSION_TOKEN",
      "AWS_CONFIG_FILE",
      "AWS_SHARED_CREDENTIALS_FILE"
    ]
  }
}
```

This lets users preserve custom provider credentials and profile-based auth chains without broadening the built-in secret allow-list.

## Why

Some model providers are configured through non-standard environment variables (for example a custom provider variable such as `CUSTOM_PROVIDER_API_KEY`). Some Bedrock setups use AWS SSO/profile resolution and require `AWS_PROFILE` plus optional AWS config path variables in the child worker.

Today `child-pi.ts` uses a hard-coded allow-list. That is safe by default, but it means these provider configurations fail in child workers even when the parent Pi session is authenticated.

This change keeps the secure default and requires explicit user opt-in.

## Security / trust boundary

- No wildcards are added to the default allow-list.
- The new `runtime.childEnvAllowList` is sanitized out of project config, same as other sensitive execution controls.
- Only user config can opt child workers into inheriting additional env vars.
- Exact env var names and trailing globs are supported by the existing `sanitizeEnvSecrets` matcher.

## Tests

Ran targeted tests:

```bash
npx tsx --test --test-concurrency=1 --test-timeout=120000 test/integration/phase3-runtime.test.ts
npx tsx --test --test-concurrency=1 --test-timeout=120000 test/unit/project-config.test.ts test/unit/config-schema-validation.test.ts
```

Results:

- phase3 runtime: 9/9 pass
- config/schema/project-config: 6/6 pass

After removing project-specific names from the PR, reran combined targeted tests:

- 15/15 pass

Note: full `npm run typecheck` currently fails on `src/runtime/dynamic-script-runner.ts` because `acorn` is not installed/resolvable in this checkout. That appears unrelated to this change.
