### PR TITLE
fix: harden child run recovery classification

### DIFF
--- a/src/runtime/child-pi.ts
+++ b/src/runtime/child-pi.ts
@@ -479,6 +479,8 @@ export async function runChildPi(input: ChildPiRunInput): Promise<ChildPiRunResu
 			const responseTimeoutMs = envInRange ? responseTimeoutEnv : input.responseTimeoutMs ?? RESPONSE_TIMEOUT_MS;
 			let responseTimeoutHit = false;
 			let forcedFinalDrain = false;
+			let finalAssistantEventObserved = false;
+			let childExitSignal: NodeJS.Signals | null = null;
 			let abortRequested = input.signal?.aborted === true;
 			let hardKilled = false;
 			const cleanupErrors: string[] = [];
@@ -572,7 +574,9 @@ export async function runChildPi(input: ChildPiRunInput): Promise<ChildPiRunResu
 						throw err;
 					}
 					input.onJsonEvent?.(event);
-					if (!isFinalAssistantEvent(event) || childExited || settled || finalDrainTimer) return;
+					if (!isFinalAssistantEvent(event)) return;
+					finalAssistantEventObserved = true;
+					if (childExited || settled || finalDrainTimer) return;
 					finalDrainTimer = setTimeout(() => {
 						if (settled || childExited) return;
 						forcedFinalDrain = true;
@@ -706,6 +710,7 @@ export async function runChildPi(input: ChildPiRunInput): Promise<ChildPiRunResu
 				settle({ exitCode: null, stdout, stderr, error: processError.message });
 			});
 			child.on("exit", (code, signal) => {
+				childExitSignal = signal;
 				if (child.pid) {
 					activeChildProcesses.delete(child.pid);
 					clearHardKillTimer(child.pid);
@@ -751,16 +756,22 @@ export async function runChildPi(input: ChildPiRunInput): Promise<ChildPiRunResu
 					logInternalError("child-pi.on-lifecycle-event", err, `event=close, pid=${child.pid}`);
 				}
 				const timeoutError = responseTimeoutHit && !stderr.trim() ? { error: `Child Pi produced no new output for ${responseTimeoutMs}ms; process was terminated as unresponsive.` } : responseTimeoutHit && stderr.trim() ? { error: `Child Pi timed out after ${responseTimeoutMs}ms with stderr: ${stderr.slice(-500)}` } : undefined;
-				// M6 fix: log when forced final drain converts non-zero exit to 0.
-			// This is expected in normal operation (child finished cleanly but linger was killed),
-			// but the telemetry helps detect regressions where crashes are hidden.
-			if (forcedFinalDrain && !timeoutError && exitCode !== 0) {
-				logInternalError("child-pi.final-drain-zero-exit", new Error(`Child exit code overridden to 0 after forced final drain (original=${exitCode})`), `pid=${child.pid}, finalDrainMs=${finalDrainMs}`);
-			}
-			const finalExitCode = forcedFinalDrain && !timeoutError ? 0 : exitCode;
+				const originalExitCode = exitCode;
+				const normalizedBy = forcedFinalDrain && !timeoutError
+					? "final_drain"
+					: finalAssistantEventObserved && exitCode === 143 && !timeoutError && !abortRequested && !hardKilled
+						? "final_assistant_event_sigterm"
+						: undefined;
+				// M6 fix: log when final-output handling converts non-zero exit to 0.
+				// This is expected in normal operation (child finished cleanly but linger was killed),
+				// but the telemetry helps detect regressions where crashes are hidden.
+				if (normalizedBy && exitCode !== 0) {
+					logInternalError("child-pi.final-output-zero-exit", new Error(`Child exit code overridden to 0 after ${normalizedBy} (original=${exitCode})`), `pid=${child.pid}, finalDrainMs=${finalDrainMs}`);
+				}
+				const finalExitCode = normalizedBy ? 0 : exitCode;
 				const wasGraceAborted = softLimitReached && turnCount >= (maxTurns ?? 0) + (graceTurns ?? 5);
 				const wasParentAborted = abortDueToParentSignal && !wasGraceAborted;
-				settle({ exitCode: finalExitCode, stdout, stderr, ...(timeoutError ? { error: timeoutError.error } : {}), aborted: wasGraceAborted || wasParentAborted, steered: softLimitReached && !wasGraceAborted, exitStatus: { exitCode: finalExitCode, cancelled: abortRequested, timedOut: responseTimeoutHit, killed: hardKilled, cleanupErrors, finalDrainMs } });
+				settle({ exitCode: finalExitCode, stdout, stderr, ...(timeoutError ? { error: timeoutError.error } : {}), aborted: wasGraceAborted || wasParentAborted, steered: softLimitReached && !wasGraceAborted, exitStatus: { exitCode: finalExitCode, originalExitCode, cancelled: abortRequested, timedOut: responseTimeoutHit, killed: hardKilled, signal: childExitSignal ?? undefined, normalizedBy, cleanupErrors, finalDrainMs } });
 			});
 		});
 	} finally {

--- a/src/runtime/crash-recovery.ts
+++ b/src/runtime/crash-recovery.ts
@@ -9,7 +9,7 @@ import type { TeamTaskState } from "../state/types.ts";
 import { isWorkerHeartbeatStale } from "./worker-heartbeat.ts";
 import type { ManifestCache } from "./manifest-cache.ts";
 import { checkProcessLiveness } from "./process-status.ts";
-import { reconcileStaleRun, type ReconcileResult } from "./stale-reconciler.ts";
+import { isPlanApprovalPending, reconcileStaleRun, type ReconcileResult } from "./stale-reconciler.ts";
 import { executeHook, appendHookEvent } from "../hooks/registry.ts";
 import { unregisterActiveRun, readActiveRunRegistry } from "../state/active-run-registry.ts";
 import { resolveRealContainedPath } from "../utils/safe-paths.ts";
@@ -38,6 +38,7 @@ export function detectInterruptedRuns(cwd: string, manifestCache: ManifestCache,
 	const plans: RecoveryPlan[] = [];
 	for (const manifest of manifestCache.list(50)) {
 		if (manifest.status !== "running" && manifest.status !== "blocked") continue;
+		if (isPlanApprovalPending(manifest)) continue;
 		if (manifest.async?.pid !== undefined && checkProcessLiveness(manifest.async.pid).alive) continue;
 		const loaded = loadRunManifestById(cwd, manifest.runId);
 		if (!loaded) continue;
@@ -106,6 +107,10 @@ export function cancelOrphanedRuns(
 	// Phase 1: Scan project-level manifests via manifestCache
 	for (const manifest of manifestCache.list(50)) {
 		if (manifest.status !== "running" && manifest.status !== "blocked") continue;
+		if (isPlanApprovalPending(manifest)) {
+			skipped.push(manifest.runId);
+			continue;
+		}
 
 		// Only consider runs owned by a different session
 		const ownerId = manifest.ownerSessionId;
@@ -322,6 +327,15 @@ export function reconcileAllStaleRuns(cwd: string, manifestCache: ManifestCache,
 	const results: ReconcileResult[] = [];
 	for (const manifest of manifestCache.list(50)) {
 		if (manifest.status !== "running" && manifest.status !== "blocked") continue;
+		if (isPlanApprovalPending(manifest)) {
+			results.push({
+				runId: manifest.runId,
+				verdict: "blocked_awaiting_approval",
+				repaired: false,
+				detail: "Plan approval is pending; stale reconciliation skipped",
+			});
+			continue;
+		}
 		const loaded = loadRunManifestById(cwd, manifest.runId);
 		if (!loaded) continue;
 		// Use lock to prevent race with cancel/status handlers modifying the same run
@@ -329,6 +343,7 @@ export function reconcileAllStaleRuns(cwd: string, manifestCache: ManifestCache,
 			// Re-read inside lock to get freshest data
 			const fresh = loadRunManifestById(cwd, manifest.runId);
 			if (!fresh || (fresh.manifest.status !== "running" && fresh.manifest.status !== "blocked")) return;
+			if (isPlanApprovalPending(fresh.manifest)) return;
 			const result = reconcileStaleRun(fresh.manifest, fresh.tasks, now);
 			if (result.repaired || result.verdict === "result_exists") {
 				if (result.repairedTasks) {

--- a/src/runtime/pi-args.ts
+++ b/src/runtime/pi-args.ts
@@ -63,29 +63,32 @@ export function checkCrewDepth(inputMaxDepth?: number, env: NodeJS.ProcessEnv = 
 
 /**
  * Create a safe temp directory with symlink protection.
- * 1. mkdtempSync to create the directory
- * 2. lstatSync to verify it is not a symlink (TOCTOU safety)
- * 3. realpathSync to resolve the canonical path
+ *
+ * macOS commonly exposes `/tmp` as a symlink to `/private/tmp`. Refusing every
+ * symlinked temp base breaks otherwise-safe child workers. Resolve the base to
+ * its canonical directory before creation, then verify the created directory is
+ * not itself a symlink and remains contained by the canonical base.
  */
 function createSafeTempDir(base: string, prefix: string): string {
 	if (!fs.existsSync(base)) fs.mkdirSync(base, { recursive: true });
-	// Verify base dir is not a symlink (TOCTOU safety)
-	const baseStat = fs.lstatSync(base);
-	if (baseStat.isSymbolicLink()) throw new Error("Refusing to create temp dir in symlinked base: " + base);
-	// Resolve base to canonical path before joining
 	const resolvedBase = fs.realpathSync(base);
 	const rawTempDir = fs.mkdtempSync(path.join(resolvedBase, prefix));
 	try {
 		const stat = fs.lstatSync(rawTempDir);
 		if (stat.isSymbolicLink()) throw new Error("temp dir is a symlink");
+		const realTempDir = fs.realpathSync(rawTempDir);
+		const relative = path.relative(resolvedBase, realTempDir);
+		if (relative.startsWith("..") || path.isAbsolute(relative)) {
+			throw new Error("temp dir escapes resolved base");
+		}
+		return realTempDir;
 	} catch (e) {
+		fs.rmSync(rawTempDir, { recursive: true, force: true });
 		if (e instanceof Error && e.message.includes("symlink")) {
-			fs.rmSync(rawTempDir, { recursive: true, force: true });
 			throw new Error("Refusing to use symlinked temp directory.");
 		}
 		throw e;
 	}
-	return fs.realpathSync(rawTempDir);
 }
 
 export function buildPiWorkerArgs(input: BuildPiWorkerArgsInput): BuildPiWorkerArgsResult {

--- a/src/runtime/stale-reconciler.ts
+++ b/src/runtime/stale-reconciler.ts
@@ -16,6 +16,7 @@ export interface ReconcileResult {
 	/** What was found and what action was taken */
 	verdict:
 		| "healthy"
+		| "blocked_awaiting_approval"
 		| "result_exists"
 		| "pid_dead"
 		| "pid_alive_stale"
@@ -26,6 +27,12 @@ export interface ReconcileResult {
 	detail: string;
 	/** Repaired task state, returned to a locked caller for persistence. */
 	repairedTasks?: TeamTaskState[];
+}
+
+export function isPlanApprovalPending(manifest: TeamRunManifest): boolean {
+	return manifest.status === "blocked" &&
+		manifest.planApproval?.required === true &&
+		manifest.planApproval.status === "pending";
 }
 
 const STALE_ALIVE_PID_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -258,6 +265,15 @@ export function reconcileStaleRun(
 	now = Date.now(),
 ): ReconcileResult {
 	const runId = manifest.runId;
+
+	if (isPlanApprovalPending(manifest)) {
+		return {
+			runId,
+			verdict: "blocked_awaiting_approval",
+			repaired: false,
+			detail: "Plan approval is pending; blocked run is intentionally waiting and must not be stale-repaired",
+		};
+	}
 
 	// Phase 1: Check if results already exist
 	const phase1 = checkResultFile(manifest, tasks);

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -110,10 +110,14 @@ export interface RuntimeResolutionState {
 
 export interface WorkerExitStatus {
 	exitCode: number | null;
+	/** Raw process exit code before any final-output normalization. */
+	originalExitCode?: number | null;
 	cancelled: boolean;
 	timedOut: boolean;
 	killed: boolean;
 	signal?: string;
+	/** Why a non-zero process exit was normalized after final output. */
+	normalizedBy?: "final_drain" | "final_assistant_event_sigterm";
 	cleanupErrors: string[];
 	finalDrainMs: number;
 }

--- a/test/integration/phase3-runtime.test.ts
+++ b/test/integration/phase3-runtime.test.ts
@@ -62,7 +62,9 @@ test("child Pi response timeout treats filtered stdout JSON as activity", async 
 	delete process.env.PI_TEAMS_MOCK_CHILD_PI;
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-crew-child-filtered-activity-"));
 	try {
-		const fakePi = path.join(process.cwd(), "node_modules", ".bin", "fake-pi-phase3.js");
+		const binDir = path.join(process.cwd(), "node_modules", ".bin");
+		fs.mkdirSync(binDir, { recursive: true });
+		const fakePi = path.join(binDir, "fake-pi-phase3.js");
 		fs.writeFileSync(fakePi, `
 console.log(JSON.stringify({ type: "message_update", message: { content: [{ type: "thinking", text: "still working" }] } }));
 setTimeout(() => console.log(JSON.stringify({ type: "message_update", message: { content: [{ type: "thinking", text: "still working" }] } })), 600);
@@ -93,7 +95,9 @@ test("child Pi final-drain termination after final assistant output is treated a
 	delete process.env.PI_TEAMS_MOCK_CHILD_PI;
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-crew-child-final-drain-"));
 	try {
-		const fakePi = path.join(process.cwd(), "node_modules", ".bin", "fake-pi-phase3-drain.js");
+		const binDir = path.join(process.cwd(), "node_modules", ".bin");
+		fs.mkdirSync(binDir, { recursive: true });
+		const fakePi = path.join(binDir, "fake-pi-phase3-drain.js");
 		fs.writeFileSync(fakePi, `
 console.log(JSON.stringify({ type: "message", message: { role: "assistant", content: [{ type: "text", text: "final answer before lingering cleanup" }] } }));
 console.log(JSON.stringify({ type: "message_end", message: { role: "assistant", content: [], stopReason: "stop" } }));
@@ -108,6 +112,40 @@ setInterval(() => {}, 1000);
 		if (previousMock === undefined) delete process.env.PI_TEAMS_MOCK_CHILD_PI;
 		else process.env.PI_CREW_ALLOW_MOCK = "1";
 	process.env.PI_TEAMS_MOCK_CHILD_PI = previousMock;
+		if (previousBin === undefined) delete process.env.PI_TEAMS_PI_BIN;
+		else process.env.PI_TEAMS_PI_BIN = previousBin;
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test("child Pi exit 143 after final assistant event is treated as completed", async () => {
+	const previousMock = process.env.PI_TEAMS_MOCK_CHILD_PI;
+	const previousBin = process.env.PI_TEAMS_PI_BIN;
+	delete process.env.PI_TEAMS_MOCK_CHILD_PI;
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-crew-child-final-143-"));
+	try {
+		const binDir = path.join(process.cwd(), "node_modules", ".bin");
+		fs.mkdirSync(binDir, { recursive: true });
+		const fakePi = path.join(binDir, "fake-pi-phase3-final-143.js");
+		fs.writeFileSync(fakePi, `
+console.log(JSON.stringify({ type: "message", message: { role: "assistant", content: [{ type: "text", text: "final answer before external termination" }] } }));
+console.log(JSON.stringify({ type: "message_end", message: { role: "assistant", content: [], stopReason: "stop" } }));
+setTimeout(() => process.exit(143), 20);
+setInterval(() => {}, 1000);
+`, "utf-8");
+		process.env.PI_TEAMS_PI_BIN = fakePi;
+		const result = await runChildPi({ cwd: dir, task: "hello", agent: { name: "mock", description: "mock", source: "builtin", filePath: "mock.md", systemPrompt: "mock" }, finalDrainMs: 10_000, hardKillMs: 100, responseTimeoutMs: 1000 });
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.error, undefined);
+		assert.equal(result.exitStatus?.originalExitCode, 143);
+		assert.equal(result.exitStatus?.normalizedBy, "final_assistant_event_sigterm");
+		assert.match(result.stdout, /final answer before external termination/);
+	} finally {
+		if (previousMock === undefined) delete process.env.PI_TEAMS_MOCK_CHILD_PI;
+		else {
+			process.env.PI_CREW_ALLOW_MOCK = "1";
+			process.env.PI_TEAMS_MOCK_CHILD_PI = previousMock;
+		}
 		if (previousBin === undefined) delete process.env.PI_TEAMS_PI_BIN;
 		else process.env.PI_TEAMS_PI_BIN = previousBin;
 		fs.rmSync(dir, { recursive: true, force: true });

--- a/test/unit/child-pi-timeout.test.ts
+++ b/test/unit/child-pi-timeout.test.ts
@@ -51,6 +51,33 @@ test("buildPiWorkerArgs creates temp file for system prompt", () => {
 	assert.ok(!fs.existsSync(result.tempDir), "tempDir should be cleaned up");
 });
 
+test("buildPiWorkerArgs accepts symlinked TMPDIR after resolving canonical base", () => {
+	if (process.platform === "win32") return;
+	const previousTmpDir = process.env.TMPDIR;
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "pi-crew-symlink-tmp-root-"));
+	const realBase = path.join(root, "real-tmp");
+	const linkBase = path.join(root, "tmp-link");
+	fs.mkdirSync(realBase);
+	try {
+		fs.symlinkSync(realBase, linkBase, "dir");
+	} catch {
+		fs.rmSync(root, { recursive: true, force: true });
+		return;
+	}
+	try {
+		process.env.TMPDIR = linkBase;
+		const agentWithPrompt: AgentConfig = { ...minimalAgent, systemPrompt: "safe temp" };
+		const result = buildPiWorkerArgs({ task: "test", agent: agentWithPrompt });
+		assert.ok(result.tempDir, "expected tempDir to be created");
+		assert.ok(fs.realpathSync(result.tempDir).startsWith(fs.realpathSync(realBase)));
+		cleanupTempDir(result.tempDir);
+	} finally {
+		if (previousTmpDir === undefined) delete process.env.TMPDIR;
+		else process.env.TMPDIR = previousTmpDir;
+		fs.rmSync(root, { recursive: true, force: true });
+	}
+});
+
 test("buildPiWorkerArgs increments depth in env vars", () => {
 	const env = { PI_CREW_DEPTH: "1", PI_TEAMS_DEPTH: "1" } as NodeJS.ProcessEnv;
 	const result = buildPiWorkerArgs({ task: "test", agent: minimalAgent, env });

--- a/test/unit/crash-recovery-cov.test.ts
+++ b/test/unit/crash-recovery-cov.test.ts
@@ -53,4 +53,28 @@ describe("detectInterruptedRuns", () => {
 			removeTrackedTempDir(dir);
 		}
 	});
+
+	it("does not recover runs blocked for plan approval", () => {
+		const dir = createTrackedTempDir("pi-crew-cr-");
+		try {
+			const now = new Date().toISOString();
+			const cache = {
+				list: () => [{
+					runId: "r-plan",
+					status: "blocked",
+					async: { pid: 99999125 },
+					planApproval: {
+						required: true,
+						status: "pending",
+						requestedAt: now,
+						updatedAt: now,
+					},
+				}],
+			};
+			const plans = detectInterruptedRuns(dir, cache as any);
+			assert.deepStrictEqual(plans, []);
+		} finally {
+			removeTrackedTempDir(dir);
+		}
+	});
 });

--- a/test/unit/stale-reconciler.test.ts
+++ b/test/unit/stale-reconciler.test.ts
@@ -122,6 +122,32 @@ describe("reconcileStaleRun", () => {
 		assert.equal(result.repaired, true);
 	});
 
+	it("preserves plan-approval blocked runs even when async PID is dead", () => {
+		const now = new Date().toISOString();
+		const manifest: TeamRunManifest = {
+			...baseManifest,
+			status: "blocked",
+			async: {
+				pid: 99999124,
+				logPath: "/tmp/log",
+				spawnedAt: now,
+			},
+			planApproval: {
+				required: true,
+				status: "pending",
+				requestedAt: now,
+				updatedAt: now,
+				planTaskId: "01_plan",
+			},
+		};
+
+		const result = reconcileStaleRun(manifest, [runningTask], Date.now());
+
+		assert.equal(result.verdict, "blocked_awaiting_approval");
+		assert.equal(result.repaired, false);
+		assert.equal(result.repairedTasks, undefined);
+	});
+
 	it("returns healthy for alive PID with recent updatedAt even with running tasks", () => {
 		const manifest = {
 			...baseManifest,


### PR DESCRIPTION
## Summary

- preserve `blocked` runs that are intentionally waiting for plan approval during stale/crash recovery
- normalize child process exit `143` only after a final assistant event has been observed, while keeping timeout/cancel/hard-kill failures as failures
- allow symlinked temp bases such as macOS `/tmp -> /private/tmp` by resolving to the canonical base and verifying created temp dirs stay contained
- add regression coverage for plan-approval blocks, final-output `143`, symlinked `TMPDIR`, and child fake-bin setup reliability

## Verification

Passed:

```bash
node --experimental-strip-types --test \
  test/unit/stale-reconciler.test.ts \
  test/unit/crash-recovery-cov.test.ts \
  test/unit/child-pi-timeout.test.ts \
  test/integration/phase3-runtime.test.ts
```

```bash
npx tsc --noEmit
```

Also ran:

```bash
npm run check:lazy-imports
```

This currently fails on existing dynamic imports unrelated to this PR (for example `src/extension/register.ts`, `src/extension/team-tool/run.ts`, `src/runtime/chain-runner.ts`, `src/runtime/task-runner.ts`, `src/state/hook-instinct-bridge.ts`, `src/utils/bm25-search.ts`).

```bash
npm test
```

This did not complete green in my local run; the custom runner exited with `12 test(s) failed` after progressing through hundreds of tests. The targeted regression set above and typecheck passed.

## Notes

This fixes the failure mode where a plan-approval-gated implementation run can later be marked failed by stale PID reconciliation, and the failure mode where a child process exits with `143` after already producing final assistant output.
