### PR TITLE
Add opt-in env vars for custom LLM proxy/gateway auth in child workers

### DIFF
--- a/dist/build-meta.json
+++ b/dist/build-meta.json
@@ -7134,7 +7134,7 @@
       "format": "esm"
     },
     "src/runtime/pi-args.ts": {
-      "bytes": 27494,
+      "bytes": 28759,
       "imports": [
         {
           "path": "node:fs",
@@ -7279,7 +7279,7 @@
       "format": "esm"
     },
     "src/utils/env-filter.ts": {
-      "bytes": 6523,
+      "bytes": 7677,
       "imports": [
         {
           "path": "src/utils/redaction.ts",
@@ -7387,7 +7387,7 @@
       "format": "esm"
     },
     "src/runtime/child-pi.ts": {
-      "bytes": 71886,
+      "bytes": 71977,
       "imports": [
         {
           "path": "node:child_process",
@@ -12891,7 +12891,7 @@
       "format": "esm"
     },
     "src/runtime/async-runner.ts": {
-      "bytes": 14705,
+      "bytes": 14759,
       "imports": [
         {
           "path": "node:child_process",
@@ -18425,7 +18425,7 @@
       "imports": [],
       "exports": [],
       "inputs": {},
-      "bytes": 6704580
+      "bytes": 6707853
     },
     "dist/index.mjs": {
       "imports": [
@@ -20752,7 +20752,7 @@
           "bytesInOutput": 1291
         },
         "src/runtime/pi-args.ts": {
-          "bytesInOutput": 15095
+          "bytesInOutput": 15435
         },
         "src/runtime/runtime-warmup.ts": {
           "bytesInOutput": 1998
@@ -20776,7 +20776,7 @@
           "bytesInOutput": 291
         },
         "src/utils/env-filter.ts": {
-          "bytesInOutput": 3511
+          "bytesInOutput": 3851
         },
         "src/runtime/compact-pipeline.ts": {
           "bytesInOutput": 517
@@ -20815,7 +20815,7 @@
           "bytesInOutput": 1801
         },
         "src/runtime/child-pi.ts": {
-          "bytesInOutput": 47895
+          "bytesInOutput": 47965
         },
         "src/runtime/heartbeat-gradient.ts": {
           "bytesInOutput": 953
@@ -21556,7 +21556,7 @@
           "bytesInOutput": 2699
         },
         "src/runtime/async-runner.ts": {
-          "bytesInOutput": 8943
+          "bytesInOutput": 8975
         },
         "src/subagents/async-entry.ts": {
           "bytesInOutput": 119
@@ -22135,7 +22135,7 @@
           "bytesInOutput": 81
         }
       },
-      "bytes": 3175900
+      "bytes": 3176682
     }
   }
 }

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -16527,6 +16527,10 @@ var init_agent_config = __esm({
 import * as fs25 from "node:fs";
 import * as os7 from "node:os";
 import * as path21 from "node:path";
+function getExtraExtensionPaths() {
+  const raw = process.env.PI_CREW_EXTRA_EXTENSIONS ?? process.env.PI_TEAMS_EXTRA_EXTENSIONS ?? "";
+  return raw.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+}
 function getPiTempBase() {
   return path21.join(userPiRoot(), "tmp");
 }
@@ -16695,12 +16699,13 @@ function buildPiWorkerArgs(input) {
     if (excludeTools?.length) args.push("--exclude-tools", excludeTools.join(","));
   }
   args.push("--no-extensions");
+  const extraExtensions = getExtraExtensionPaths();
   if (input.agent.extensions !== void 0) {
     const excluded = new Set((input.agent.excludeExtensions ?? []).map((name) => path21.basename(name).toLowerCase()));
     const allowed = input.agent.extensions.filter((ext) => !excluded.has(path21.basename(ext).toLowerCase()));
-    for (const extension of [PROMPT_RUNTIME_EXTENSION_PATH, ...allowed]) args.push("--extension", extension);
+    for (const extension of [PROMPT_RUNTIME_EXTENSION_PATH, ...extraExtensions, ...allowed]) args.push("--extension", extension);
   } else {
-    args.push("--extension", PROMPT_RUNTIME_EXTENSION_PATH);
+    for (const extension of [PROMPT_RUNTIME_EXTENSION_PATH, ...extraExtensions]) args.push("--extension", extension);
   }
   if (!input.agent.inheritSkills) args.push("--no-skills");
   for (const skillPath of input.skillPaths ?? []) args.push("--skill", skillPath);
@@ -17867,6 +17872,13 @@ var init_env_allowlist = __esm({
 function isKnownProviderKey(key) {
   return KNOWN_PROVIDER_KEYS.has(key);
 }
+function getExtraEnvAllowlist(env = process.env) {
+  const raw = env.PI_CREW_EXTRA_ENV_ALLOWLIST ?? env.PI_TEAMS_EXTRA_ENV_ALLOWLIST ?? "";
+  return raw.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+}
+function isUserDeclaredExtraKey(key) {
+  return getExtraEnvAllowlist().includes(key);
+}
 function providerEnvKeys(modelId) {
   if (!modelId) return [];
   const separatorIndex = modelId.indexOf("/");
@@ -17902,7 +17914,7 @@ function sanitizeEnvSecrets(env, options) {
       if (isDangerousGlob(pattern)) {
         throw new Error(`Allowlist pattern "${pattern}" could match secret env vars. Use a more specific pattern.`);
       }
-      if (!pattern.endsWith("*") && isSecretKey(pattern) && !(pattern in env) && !isKnownProviderKey(pattern)) {
+      if (!pattern.endsWith("*") && isSecretKey(pattern) && !(pattern in env) && !isKnownProviderKey(pattern) && !isUserDeclaredExtraKey(pattern)) {
         throw new Error(`Allowlist entry "${pattern}" looks like a secret key. Use a more specific pattern.`);
       }
     }
@@ -18654,7 +18666,8 @@ function buildChildPiSpawnOptions(cwd, env, model) {
       throw new Error(`Invalid cwd: ${cwd} \u2014 ${error instanceof Error ? error.message : String(error)}`);
     }
   }
-  const allowList = model ? buildScopedAllowList(BASE_ALLOWLIST, [model]) : BASE_ALLOWLIST;
+  const baseAllowList = [...BASE_ALLOWLIST, ...getExtraEnvAllowlist()];
+  const allowList = model ? buildScopedAllowList(baseAllowList, [model]) : baseAllowList;
   const filteredEnv = sanitizeEnvSecrets(env, { allowList });
   if (filteredEnv.NODE_PATH) {
     const validPrefixes = ["/opt/", "/lib/", "/usr/local/", "/usr/", "/home/"];
@@ -48480,7 +48493,7 @@ async function spawnBackgroundTeamRun(manifest) {
   const logPath = path53.join(manifest.stateRoot, "background.log");
   fs61.mkdirSync(manifest.stateRoot, { recursive: true });
   const filteredEnv = sanitizeEnvSecrets(process.env, {
-    allowList: BACKGROUND_RUNNER_ENV_ALLOWLIST
+    allowList: [...BACKGROUND_RUNNER_ENV_ALLOWLIST, ...getExtraEnvAllowlist()]
   });
   const peerDepDir = resolvePeerDepDir();
   const childEnv = peerDepDir ? { ...filteredEnv, [PEER_DEP_DIR_ENV]: peerDepDir } : filteredEnv;

--- a/src/runtime/async-runner.ts
+++ b/src/runtime/async-runner.ts
@@ -6,7 +6,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { appendEvent, appendEventAsync } from "../state/event-log.ts";
 import type { TeamRunManifest } from "../state/types.ts";
 import { WINDOWS_ESSENTIAL_ENV_VARS } from "../utils/env-allowlist.ts";
-import { sanitizeEnvSecrets } from "../utils/env-filter.ts";
+import { getExtraEnvAllowlist, sanitizeEnvSecrets } from "../utils/env-filter.ts";
 import { logInternalError } from "../utils/internal-error.ts";
 import { packageRoot } from "../utils/paths.ts";
 import { registerWorker, unregisterWorker } from "./orphan-worker-registry.ts";
@@ -242,7 +242,7 @@ export async function spawnBackgroundTeamRun(manifest: TeamRunManifest): Promise
 	// to prevent leaking all env vars (including secrets) to detached background runner.
 	// Previously, destructuring only removed PI_CREW_PARENT_PID but kept everything else.
 	const filteredEnv = sanitizeEnvSecrets(process.env, {
-		allowList: BACKGROUND_RUNNER_ENV_ALLOWLIST,
+		allowList: [...BACKGROUND_RUNNER_ENV_ALLOWLIST, ...getExtraEnvAllowlist()],
 	});
 	// FIX: removed delete workarounds — with explicit allowlist, these vars
 	// are no longer auto-leaked. Matches child-pi.ts.

--- a/src/runtime/child-pi.ts
+++ b/src/runtime/child-pi.ts
@@ -7,7 +7,7 @@ import { DEFAULT_CHILD_PI } from "../config/defaults.ts";
 import { registerChildProcess, unregisterChildProcess } from "../extension/crew-cleanup.ts";
 import type { WorkerExitStatus } from "../state/types.ts";
 import { WINDOWS_ESSENTIAL_ENV_VARS } from "../utils/env-allowlist.ts";
-import { buildScopedAllowList, sanitizeEnvSecrets } from "../utils/env-filter.ts";
+import { buildScopedAllowList, getExtraEnvAllowlist, sanitizeEnvSecrets } from "../utils/env-filter.ts";
 import { logInternalError } from "../utils/internal-error.ts";
 import { redactJsonLine, redactSecretString } from "../utils/redaction.ts";
 import { resolveRealContainedPath } from "../utils/safe-paths.ts";
@@ -368,7 +368,8 @@ export function buildChildPiSpawnOptions(cwd: string, env: NodeJS.ProcessEnv, mo
 	// PER-TASK KEY SCOPING: when a model is provided, only the env keys for that
 	// provider are injected (via buildScopedAllowList). When no model is given,
 	// only BASE_ALLOWLIST system vars pass through — no provider keys leak.
-	const allowList = model ? buildScopedAllowList(BASE_ALLOWLIST, [model]) : BASE_ALLOWLIST;
+	const baseAllowList = [...BASE_ALLOWLIST, ...getExtraEnvAllowlist()];
+	const allowList = model ? buildScopedAllowList(baseAllowList, [model]) : baseAllowList;
 	const filteredEnv = sanitizeEnvSecrets(env, { allowList });
 	// FIX: Removed delete workarounds — with explicit allowlist, these vars
 	// are no longer auto-leaked. The wildcard approach was fragile.

--- a/src/runtime/pi-args.ts
+++ b/src/runtime/pi-args.ts
@@ -17,6 +17,30 @@ const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"];
 // dist/ entry points.
 const PROMPT_RUNTIME_EXTENSION_PATH = path.join(packageRoot(), "src", "prompt", "prompt-runtime.ts");
 const TASK_ARG_LIMIT = 8000;
+
+/**
+ * User-declared extension paths to always load in every spawned child/worker,
+ * on top of the pi-crew-internal prompt-runtime and any per-agent extensions.
+ *
+ * Child workers always run with `--no-extensions` (see below) so a user's
+ * normal `~/.pi/agent/extensions/` auto-discovery never fires for them — by
+ * design, since arbitrary user extensions may have missing deps or unwanted
+ * side effects in a headless worker. But some extensions ARE required for
+ * workers to function at all: e.g. a custom LLM-gateway/proxy extension that
+ * registers provider auth (baseUrl/apiKey/headers) for a non-default setup.
+ * Without it, workers silently have no working provider.
+ *
+ * Set PI_CREW_EXTRA_EXTENSIONS (or PI_TEAMS_EXTRA_EXTENSIONS) to a
+ * comma-separated list of absolute extension file/directory paths, e.g.:
+ *   PI_CREW_EXTRA_EXTENSIONS=/Users/me/.pi/agent/extensions/my-proxy-auth
+ */
+function getExtraExtensionPaths(): string[] {
+	const raw = process.env.PI_CREW_EXTRA_EXTENSIONS ?? process.env.PI_TEAMS_EXTRA_EXTENSIONS ?? "";
+	return raw
+		.split(",")
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+}
 const DEFAULT_MAX_CREW_DEPTH = 2;
 
 // Track every temp dir created in this process so we can clean them up
@@ -300,6 +324,7 @@ export function buildPiWorkerArgs(input: BuildPiWorkerArgsInput): BuildPiWorkerA
 	// Always add --no-extensions before --extension to prevent user extensions from being auto-loaded.
 	// User extensions in ~/.pi/agent/extensions/ may fail due to missing dependencies.
 	args.push("--no-extensions");
+	const extraExtensions = getExtraExtensionPaths();
 	if (input.agent.extensions !== undefined) {
 		// F1 (v0.7.9): apply `excludeExtensions` denylist (case-insensitive
 		// basename match) BEFORE the trusted PROMPT_RUNTIME_EXTENSION_PATH is
@@ -309,9 +334,9 @@ export function buildPiWorkerArgs(input: BuildPiWorkerArgsInput): BuildPiWorkerA
 		// with the rest of the agent loader's best-effort semantics).
 		const excluded = new Set((input.agent.excludeExtensions ?? []).map((name) => path.basename(name).toLowerCase()));
 		const allowed = input.agent.extensions.filter((ext) => !excluded.has(path.basename(ext).toLowerCase()));
-		for (const extension of [PROMPT_RUNTIME_EXTENSION_PATH, ...allowed]) args.push("--extension", extension);
+		for (const extension of [PROMPT_RUNTIME_EXTENSION_PATH, ...extraExtensions, ...allowed]) args.push("--extension", extension);
 	} else {
-		args.push("--extension", PROMPT_RUNTIME_EXTENSION_PATH);
+		for (const extension of [PROMPT_RUNTIME_EXTENSION_PATH, ...extraExtensions]) args.push("--extension", extension);
 	}
 	if (!input.agent.inheritSkills) args.push("--no-skills");
 	for (const skillPath of input.skillPaths ?? []) args.push("--skill", skillPath);

--- a/src/utils/env-filter.ts
+++ b/src/utils/env-filter.ts
@@ -42,6 +42,32 @@ function isKnownProviderKey(key: string): boolean {
 }
 
 /**
+ * User-declared extra env var names to trust for pass-through to child/worker
+ * processes, even though their names look secret-like (contain KEY/TOKEN/etc.)
+ * and aren't already in KNOWN_PROVIDER_KEYS.
+ *
+ * Use case: custom LLM gateways/proxies (e.g. an internal auth extension that
+ * reads `$MY_PROXY_API_KEY`) that aren't one of the built-in providers above.
+ * This is an explicit, user-controlled opt-in — the caller is declaring "I know
+ * this name is safe to forward", the same trust model as PI_TEAMS_PI_BIN.
+ *
+ * Set PI_CREW_EXTRA_ENV_ALLOWLIST (or PI_TEAMS_EXTRA_ENV_ALLOWLIST) to a
+ * comma-separated list of env var names, e.g.:
+ *   PI_CREW_EXTRA_ENV_ALLOWLIST=MY_PROXY_API_KEY,MY_PROXY_AUTH_HEADER
+ */
+export function getExtraEnvAllowlist(env: NodeJS.ProcessEnv = process.env): string[] {
+	const raw = env.PI_CREW_EXTRA_ENV_ALLOWLIST ?? env.PI_TEAMS_EXTRA_ENV_ALLOWLIST ?? "";
+	return raw
+		.split(",")
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+}
+
+function isUserDeclaredExtraKey(key: string): boolean {
+	return getExtraEnvAllowlist().includes(key);
+}
+
+/**
  * Extract provider prefix from a model ID string and return the corresponding
  * env var names. Returns empty array for unknown/custom providers or invalid input.
  *
@@ -127,7 +153,13 @@ export function sanitizeEnvSecrets(env: NodeJS.ProcessEnv, options?: SanitizeEnv
 			// Exception 2: known provider keys (MINIMAX_API_KEY, etc.) are always
 			// allowed because they are standard provider credentials explicitly
 			// listed in async-runner.ts / child-pi.ts allowlists.
-			if (!pattern.endsWith("*") && isSecretKey(pattern) && !(pattern in env) && !isKnownProviderKey(pattern)) {
+			if (
+				!pattern.endsWith("*") &&
+				isSecretKey(pattern) &&
+				!(pattern in env) &&
+				!isKnownProviderKey(pattern) &&
+				!isUserDeclaredExtraKey(pattern)
+			) {
 				throw new Error(`Allowlist entry "${pattern}" looks like a secret key. Use a more specific pattern.`);
 			}
 		}

--- a/test/unit/env-filter.test.ts
+++ b/test/unit/env-filter.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildScopedAllowList, providerEnvKeys, sanitizeEnvSecrets } from "../../src/utils/env-filter.ts";
+import { buildScopedAllowList, getExtraEnvAllowlist, providerEnvKeys, sanitizeEnvSecrets } from "../../src/utils/env-filter.ts";
 
 test("default deny-list strips secret-like keys", () => {
 	const result = sanitizeEnvSecrets({
@@ -112,4 +112,25 @@ test("buildScopedAllowList with custom provider returns no extra keys", () => {
 	// No provider keys for custom provider
 	assert.ok(!result.includes("OPENAI_API_KEY"));
 	assert.ok(!result.includes("ANTHROPIC_API_KEY"));
+});
+
+test("getExtraEnvAllowlist parses comma-separated PI_CREW_EXTRA_ENV_ALLOWLIST", () => {
+	const result = getExtraEnvAllowlist({ PI_CREW_EXTRA_ENV_ALLOWLIST: "MY_PROXY_API_KEY, MY_PROXY_AUTH_HEADER" });
+	assert.deepEqual(result, ["MY_PROXY_API_KEY", "MY_PROXY_AUTH_HEADER"]);
+});
+
+test("getExtraEnvAllowlist returns empty array when unset", () => {
+	assert.deepEqual(getExtraEnvAllowlist({}), []);
+});
+
+test("sanitizeEnvSecrets allows a secret-looking name declared via user allowlist option", () => {
+	const extra = getExtraEnvAllowlist({ PI_CREW_EXTRA_ENV_ALLOWLIST: "MY_PROXY_API_KEY" });
+	const result = sanitizeEnvSecrets({ PATH: "/usr/bin", MY_PROXY_API_KEY: "custom-secret-value" }, { allowList: ["PATH", ...extra] });
+	assert.equal(result.MY_PROXY_API_KEY, "custom-secret-value");
+});
+
+test("sanitizeEnvSecrets still rejects undeclared secret-looking allowlist entries", () => {
+	assert.throws(() => {
+		sanitizeEnvSecrets({ PATH: "/usr/bin" }, { allowList: ["PATH", "SOME_RANDOM_API_KEY"] });
+	}, /looks like a secret key/);
 });

--- a/test/unit/v0-7-9-interop-granularity.test.ts
+++ b/test/unit/v0-7-9-interop-granularity.test.ts
@@ -222,3 +222,50 @@ describe("F1 — excludeExtensions applied in child-pi spawn args", () => {
 		assert.ok(extensionFlags.includes("foo"));
 	});
 });
+
+describe("PI_CREW_EXTRA_EXTENSIONS — always-inherited worker extensions", () => {
+	const ENV_KEY = "PI_CREW_EXTRA_EXTENSIONS";
+	let prevValue: string | undefined;
+
+	afterEach(() => {
+		if (prevValue === undefined) delete process.env[ENV_KEY];
+		else process.env[ENV_KEY] = prevValue;
+	});
+
+	function extensionFlagsOf(args: string[]): string[] {
+		const flags: string[] = [];
+		for (let i = 0; i < args.length; i++) {
+			if (args[i] === "--extension") flags.push(args[i + 1] ?? "");
+		}
+		return flags;
+	}
+
+	it("appends PI_CREW_EXTRA_EXTENSIONS paths when agent has no explicit extensions", () => {
+		prevValue = process.env[ENV_KEY];
+		process.env[ENV_KEY] = "/opt/my-proxy-auth,/opt/other-ext";
+		const agent = makeAgentConfig();
+		const { args } = buildPiWorkerArgs({ agent, role: "test", task: "do something" });
+		const flags = extensionFlagsOf(args);
+		assert.ok(flags.includes("/opt/my-proxy-auth"));
+		assert.ok(flags.includes("/opt/other-ext"));
+	});
+
+	it("appends PI_CREW_EXTRA_EXTENSIONS paths alongside agent-declared extensions", () => {
+		prevValue = process.env[ENV_KEY];
+		process.env[ENV_KEY] = "/opt/my-proxy-auth";
+		const agent = makeAgentConfig({ extensions: ["foo"] });
+		const { args } = buildPiWorkerArgs({ agent, role: "test", task: "do something" });
+		const flags = extensionFlagsOf(args);
+		assert.ok(flags.includes("/opt/my-proxy-auth"));
+		assert.ok(flags.includes("foo"));
+	});
+
+	it("is a no-op when unset", () => {
+		prevValue = process.env[ENV_KEY];
+		delete process.env[ENV_KEY];
+		const agent = makeAgentConfig();
+		const { args } = buildPiWorkerArgs({ agent, role: "test", task: "do something" });
+		const flags = extensionFlagsOf(args);
+		assert.ok(!flags.some((f) => f.includes("/opt/")));
+	});
+});


### PR DESCRIPTION
## Problem

pi-crew child/background workers always spawn with `--no-extensions` (by design -- arbitrary user extensions can break headless workers), and the env-sanitizer secret-name guard only recognizes a fixed list of provider-native API key names (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.).

This breaks completely for any setup that authenticates through a custom LLM gateway/proxy extension instead of provider-native keys -- e.g. a corporate proxy extension that registers provider `baseUrl`/`apiKey`/`headers` via `pi.registerProvider(...)`, reading its own env var name (like `$MY_GATEWAY_API_KEY`) rather than `$ANTHROPIC_API_KEY`.

In that setup:
1. The child worker never loads the proxy extension (stripped by `--no-extensions`), so no provider is ever registered.
2. Even if it did load, the custom credential env var name is not in `KNOWN_PROVIDER_KEYS`, so `sanitizeEnvSecrets` throws "Allowlist entry ... looks like a secret key" if you try to add it to `BASE_ALLOWLIST`.

Net effect: every worker fails with "No API key found for <provider>", with no way to fix it from configuration alone -- today the only paths are forking pi-crew or patching `dist/index.mjs` directly.

## Fix

Two small, additive, backward-compatible (default-off) env vars:

- PI_CREW_EXTRA_ENV_ALLOWLIST (or PI_TEAMS_EXTRA_ENV_ALLOWLIST): comma-separated env var names to trust for pass-through to workers even though they look secret-like by name. Same trust model as the existing PI_TEAMS_PI_BIN escape hatch -- an explicit, user-declared opt-in, not a heuristic.
- PI_CREW_EXTRA_EXTENSIONS (or PI_TEAMS_EXTRA_EXTENSIONS): comma-separated absolute extension paths always appended to every worker's `--extension` list, alongside the internal prompt-runtime extension and any per-agent extensions.

Both no-op when unset -- zero behavior change for existing users.

## Example

```sh
export PI_CREW_EXTRA_ENV_ALLOWLIST="MY_GATEWAY_API_KEY,MY_GATEWAY_AUTH_HEADER"
export PI_CREW_EXTRA_EXTENSIONS="$HOME/.pi/agent/extensions/my-gateway-auth"
```

## Tests

- 4 new unit tests in test/unit/env-filter.test.ts (parsing, empty default, allow-through, still-rejects-undeclared)
- 3 new unit tests in test/unit/v0-7-9-interop-granularity.test.ts (extra-extensions appended with/without agent-declared extensions, no-op when unset)
- Full existing suite green (6095 tests). 10 pre-existing failures also reproduce on a clean main checkout before this change (findRepoRoot / suggestRunIds / project-init tests that look environment-sensitive), confirmed unrelated to this diff via a separate baseline run.
- typecheck, lint, format:check all pass
