### PR TITLE
fix(widget): stop crew widget flicker during agent work

### DIFF
--- a/src/extension/registration/lifecycle-handlers.ts
+++ b/src/extension/registration/lifecycle-handlers.ts
@@ -670,16 +670,16 @@ function setupRenderLoop(
 	const effectiveRefreshMs = () => (hasActiveWork() ? liveRefreshMs : fallbackMs);
 	ctx.renderScheduler = new RenderScheduler(pi.events, renderTick, {
 		fallbackMs: effectiveRefreshMs,
-		onInvalidate: (payload: unknown) => {
-			const runId =
-				typeof payload === "object" &&
-				payload !== null &&
-				"runId" in payload &&
-				typeof (payload as { runId: unknown }).runId === "string"
-					? (payload as { runId: string }).runId
-					: undefined;
-			ctx.getRunSnapshotCache(extensionCtx.cwd).invalidate(runId);
-		},
+		// ponytail: onInvalidate is intentionally a no-op.
+		// The snapshot cache refreshes itself via its own onChannel → scheduleRefresh
+		// subscription (80ms coalesced, non-destructive — marks stale, never deletes).
+		// Calling invalidate(runId) here hard-deletes the entry (entries.delete), and the
+		// crew widget path uses snapshotCache.get() (returns undefined, no rebuild) while
+		// Dashboard/Sidebar use refreshIfStale() (rebuild). So every runEventBus event
+		// made the widget flash between "(loading…)" and the full agent list at 2–5Hz.
+		// cache-control.ts invalidateSnapshot() calls invalidate() directly + emits its
+		// own event, so it does not depend on this callback.
+		onInvalidate: () => {},
 	});
 	// Fix D: bridge internal runEventBus events to renderScheduler so the UI
 	// re-renders within debounceMs of any agent lifecycle event.

--- a/src/ui/widget/index.ts
+++ b/src/ui/widget/index.ts
@@ -108,6 +108,12 @@ class CrewWidgetComponent implements WidgetComponent {
 	private cachedLines: string[] = [];
 	private cachedBaseLines: string[] = [];
 	private cachedTheme: CrewTheme;
+	/** Peak line count seen during the current active cycle. The widget pads
+	 * returned lines up to this height so the terminal layout never reflows
+	 * when agents spawn/complete mid-run (only the content changes, not the
+	 * height). Reset to 0 when all runs leave the display-active set, so the
+	 * widget disappears cleanly once every task is done. */
+	private peakHeight = 0;
 	private readonly tui: unknown;
 	private readonly unsubscribeTheme: () => void;
 	private readonly renderScheduler: RenderScheduler;
@@ -228,6 +234,7 @@ class CrewWidgetComponent implements WidgetComponent {
 
 		if (runs.length === 0) {
 			this.invalidate();
+			this.peakHeight = 0; // all tasks done → release reserved height, widget disappears
 			// P0-6: render from snapshots only — never read disk on every render tick.
 			// When the snapshot cache is provided but hasn't populated yet, paint a
 			// single "(loading…)" line so the pre-load frame is well-formed instead
@@ -238,7 +245,13 @@ class CrewWidgetComponent implements WidgetComponent {
 
 		const updatedHeader = `${runningGlyph}${this.cachedBaseLines[0]?.slice(1) ?? ""}`;
 		this.cachedLines[0] = truncate(colorWidgetLine(updatedHeader, 0, this.theme), width);
-		return this.cachedLines.map((line) => truncate(line, width));
+		const out = this.cachedLines.map((line) => truncate(line, width));
+		// Lock height to the peak seen this cycle: pad with blank rows so agent
+		// spawn/complete never changes the widget height (only content changes).
+		// Resets to 0 once all runs leave the display-active set (runs.length===0).
+		this.peakHeight = Math.max(this.peakHeight, out.length);
+		while (out.length < this.peakHeight) out.push("");
+		return out;
 	}
 }
 


### PR DESCRIPTION
## Problem

The crew widget in the Pi TUI **flickers continuously at 2–5Hz while sub-agents are running** — the progress rows appear, vanish into a single `"(loading…)"` line, reappear, and repeat. Two intertwined causes.

## Cause 1 — Content flicker: `onInvalidate` hard-deletes the snapshot cache

The session `RenderScheduler`'s `onInvalidate` callback (`lifecycle-handlers.ts`) calls `snapshotCache.invalidate(runId)`, which **hard-deletes** the cache entry (`entries.delete`, not a stale marker).

The crew widget reads snapshots via `get()` (returns `undefined`, no rebuild) — unlike `RunDashboard` / `LiveRunSidebar` which use `refreshIfStale()` (rebuilds on miss). So every `runEventBus` event:

| time | event | effect |
|---|---|---|
| t=0 | `runEventBus.emit` → `onAny` → `schedule()` | sets 50ms invalidate timer + 75ms render timer |
| t=50 | `flushInvalidate` → `onInvalidate` | `snapshotCache.invalidate(runId)` → **`entries.delete(runId)`** |
| t=75 | `flush` → `render` → `activeWidgetRuns` | `get()` → `undefined` → run dropped → widget paints **`"(loading…)"`** (1 line) |
| t=80 | `onChannel` → `scheduleRefresh` | rebuilds the entry |
| t=160 | preload loop → `render` | cache populated → **full agent list** (N lines) |
| next event | cycle repeats | blink |

The snapshot cache **already refreshes itself correctly** via its own `onChannel` → `scheduleRefresh` subscription (80ms coalesced, non-destructive — marks stale, never deletes). The `onInvalidate` delete was redundant and actively broke that mechanism.

A prior flicker fix (`run-snapshot-cache.ts:976-986` comment) only patched the `onChannel` path (delete → `scheduleRefresh`) but left this independent `onInvalidate` path still hard-deleting the same entries — a half-fix.

**Fix:** make `onInvalidate` a no-op. Verified the callback's only consumer was this cache deletion; `cache-control.ts` `invalidateSnapshot()` calls `invalidate()` directly and emits its own event, so it does not depend on the callback.

## Cause 2 — Height flicker: widget reflows when agent count changes

`buildWidgetLines()` emits 1 header + 1 run line + 2 lines per agent. When an agent spawns/completes the line count changes → widget height changes → terminal reflows. This is a residual "1-line height" flicker that remains even after fixing cause 1.

**Fix:** track `peakHeight` (max line count seen during the active cycle) in `CrewWidgetComponent` and pad the returned lines with blank rows up to that height, so agent spawn/complete only changes content, not height. Reset to `0` when all runs leave the display-active set (`runs.length === 0`), so the widget disappears cleanly once every task is done.

## Verification

- `tsc --noEmit` passes
- Full unit suite: **6192 tests, 0 failures** (incl. `crew-widget`, `render-scheduler`, `run-snapshot-cache`, `render-coalescer`)

## Files changed

- `src/extension/registration/lifecycle-handlers.ts` — `onInvalidate` → no-op (cause 1)
- `src/ui/widget/index.ts` — `peakHeight` lock + padding (cause 2)

Both changes are minimal and localized. Happy to split into two PRs if preferred.