### PR TITLE
fix: remove corrupted YAML trigger in real-test-pi-crew SKILL.md

### DIFF
--- a/skills/real-test-pi-crew/SKILL.md
+++ b/skills/real-test-pi-crew/SKILL.md
@@ -17,7 +17,6 @@ triggers:
   - "worker timeout"
   - "verifier hangs"
   - "rebuild and retry"
-  - "unknown type" tool error
   - "validation failed for tool"
   - "team tool broken"
   - "schema fix"

--- a/test/unit/discover-skills.test.ts
+++ b/test/unit/discover-skills.test.ts
@@ -198,4 +198,24 @@ describe("discoverSkills", () => {
 			fs.rmSync(cwd, { recursive: true, force: true });
 		}
 	});
+
+	// Regression: real-test-pi-crew once shipped a corrupted YAML trigger
+	// item (`- "unknown type" tool error`) that broke frontmatter parsing and
+	// emitted a HARD diagnostic. Guard that this specific bundled skill always
+	// parses and registers cleanly.
+	it("real-test-pi-crew SKILL.md parses without HARD diagnostics", () => {
+		const skillDir = path.resolve(import.meta.dirname, "..", "..", "skills", "real-test-pi-crew");
+		const skillMd = path.join(skillDir, "SKILL.md");
+		assert.ok(fs.existsSync(skillMd), "real-test-pi-crew/SKILL.md must exist");
+		const skills = discoverSkills(path.dirname(skillDir));
+		const rtpc = skills.find((s) => s.name === "real-test-pi-crew");
+		assert.ok(rtpc, "real-test-pi-crew should be discovered as a bundled skill");
+		const diagnostics = getLastDiscoveryDiagnostics();
+		const hard = diagnostics.filter((d) => d.severity === "error" && d.path === skillDir);
+		assert.equal(
+			hard.length,
+			0,
+			`real-test-pi-crew must produce no HARD diagnostics; got: ${JSON.stringify(hard, null, 2)}`,
+		);
+	});
 });


### PR DESCRIPTION
## Summary
- The bundled `real-test-pi-crew` skill shipped a malformed frontmatter trigger item (`- "unknown type" tool error`) that broke YAML parsing.
- This emitted a HARD discovery diagnostic, which surfaces as a **"Skill conflicts"** warning on every Pi startup for anyone with `pi-crew` installed.
- Removed the corrupted line so the frontmatter parses cleanly.

## Root cause
A stray, unquoted fragment of an error message was injected into the `triggers:` YAML list (between `"rebuild and retry"` and `"validation failed for tool"`). The YAML parser saw `"unknown type"` as a quoted scalar followed by dangling ` tool error` tokens → "Unexpected scalar at node end".

## Test plan
- Added regression test `real-test-pi-crew SKILL.md parses without HARD diagnostics` in `test/unit/discover-skills.test.ts`.
- `node scripts/test-runner.mjs --test-force-exit 'test/unit/discover-skills.test.ts'` → 11/11 pass (including the new case).
- This also keeps the existing `"includes bundled package skills with valid frontmatter"` test green (it asserts bundled skills emit no HARD diagnostics).

## Impact
Fixes the startup "Skill conflicts" warning for the `real-test-pi-crew` skill. No behavioral change to the extension's runtime.