### PR TITLE
fix(model-routing): don't warn for catalog-enumerated fallback refs

### DIFF
--- a/src/runtime/model/model-fallback.ts
+++ b/src/runtime/model/model-fallback.ts
@@ -293,17 +293,28 @@ export function resetPassthroughWarnings(): void {
 	passthroughWarned.clear();
 }
 
+export interface ResolveModelCandidateOptions {
+	/** Refs enumerated from the model catalog are validated by construction;
+	 *  the passthrough warning is for hand-asserted refs only. */
+	fromCatalog?: boolean;
+}
+
 export function resolveModelCandidate(
 	model: string | undefined,
 	availableModels: AvailableModelInfo[] | undefined,
 	preferredProvider?: string,
+	options?: ResolveModelCandidateOptions,
 ): string | undefined {
 	if (!model) return undefined;
 	// Provider-qualified refs ("provider/model") pass through UNVALIDATED —
 	// the caller asserted a full id; there is nothing to resolve. Loud (R8):
-	// this is the documented trust path, not a silent one.
+	// this is the documented trust path, not a silent one. Refs enumerated
+	// from the catalog itself (auto fallback tail) are the exception: they
+	// are catalog entries, so warning about them is a false positive.
 	if (model.includes("/")) {
-		warnUnvalidatedPassthrough(model, "provider-qualified ref, no catalog check");
+		if (!options?.fromCatalog) {
+			warnUnvalidatedPassthrough(model, "provider-qualified ref, no catalog check");
+		}
 		return model;
 	}
 	if (!availableModels || availableModels.length === 0) {
@@ -439,12 +450,13 @@ export function buildModelCandidates(
 	fallbackModels: string[] | undefined,
 	availableModels: AvailableModelInfo[] | undefined,
 	preferredProvider?: string,
+	options?: ResolveModelCandidateOptions,
 ): string[] {
 	const seen = new Set<string>();
 	const candidates: string[] = [];
 	for (const raw of [primaryModel, ...(fallbackModels ?? [])]) {
 		if (!raw) continue;
-		const normalized = resolveModelCandidate(raw.trim(), availableModels, preferredProvider);
+		const normalized = resolveModelCandidate(raw.trim(), availableModels, preferredProvider, options);
 		if (!normalized || seen.has(normalized)) continue;
 		seen.add(normalized);
 		candidates.push(normalized);
@@ -734,7 +746,7 @@ export function buildConfiguredModelRouting(input: {
 	// only auto candidate is the inherited parent model.
 	const autoRaw = availableModels ? availableModels.map((model) => model.fullId) : parentModel ? [parentModel] : [];
 	const declaredSet = new Set(declaredCandidates);
-	const autoResolved = buildModelCandidates(undefined, autoRaw, availableModels, preferredProvider).filter(
+	const autoResolved = buildModelCandidates(undefined, autoRaw, availableModels, preferredProvider, { fromCatalog: true }).filter(
 		(candidate) => !declaredSet.has(candidate),
 	);
 	const anchorProvider = providerOfModelRef(declaredCandidates[0]) ?? providerOfModelRef(parentModel);

--- a/test/unit/runtime/model/model-budget-summary.test.ts
+++ b/test/unit/runtime/model/model-budget-summary.test.ts
@@ -10,7 +10,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import test from "node:test";
 import { summarizeModelBudget } from "../../../../src/runtime/model/model-budget-summary.ts";
-import { resetPassthroughWarnings, resolveModelCandidate } from "../../../../src/runtime/model/model-fallback.ts";
+import { buildModelCandidates, resetPassthroughWarnings, resolveModelCandidate } from "../../../../src/runtime/model/model-fallback.ts";
 import { computeSpawnBudgetMax } from "../../../../src/runtime/task-runner/child-executor.ts";
 import type { TeamRunManifest, TeamTaskState } from "../../../../src/state/types.ts";
 import { renderTranscriptPane } from "../../../../src/ui/dashboard-panes/transcript-pane.ts";
@@ -90,6 +90,25 @@ test("passthrough warning: no-catalog and no-match paths warn with their reasons
 	assert.ok(reasons.includes("no model catalog available"), String(reasons));
 	assert.ok(reasons.includes("no exact or fuzzy catalog match"), String(reasons));
 	assert.equal(reasons.filter((r) => r === "provider-qualified ref, no catalog check").length, 0, "different models do not collide");
+});
+
+test("passthrough warning: catalog-enumerated refs (auto fallback tail) stay silent; hand-asserted refs still warn", () => {
+	resetPassthroughWarnings();
+	const original = console.warn;
+	const warned: string[] = [];
+	console.warn = (msg: string) => warned.push(String(msg));
+	try {
+		// The auto fallback tail enumerates catalog entries — every OpenRouter-style
+		// id contains "/", but these are validated by construction.
+		const autoTail = buildModelCandidates(undefined, ["zai/glm-5.3", "qwencoder/qwen3.7-max"], CATALOG, undefined, { fromCatalog: true });
+		assert.deepEqual(autoTail, ["zai/glm-5.3", "qwencoder/qwen3.7-max"]);
+		// Hand-asserted provider-qualified ref keeps the loud trust-path warning.
+		assert.equal(buildModelCandidates(undefined, ["zai/glm-5.3"], CATALOG).length, 1);
+	} finally {
+		console.warn = original;
+	}
+	const passthrough = warned.filter((w) => w.includes("provider-qualified ref"));
+	assert.equal(passthrough.length, 1, "exactly the hand-asserted ref warns");
 });
 
 function snapshotWith(tasks: TeamTaskState[]): RunUiSnapshot {


### PR DESCRIPTION
## Problem

With an OpenRouter-style catalog, every crew run floods the TUI with warnings like:

```
[model-routing] unvalidated passthrough: 'openrouter/~google/gemini-pro-latest' (provider-qualified ref, no catalog check) — not confirmed against the configured model catalog; spawn may fail at the provider.
```

~20 lines per spawned child agent, on every run.

## Root cause

Two features collide in the model-fallback layer:

1. The **auto fallback tail** enumerates every model in the configured catalog (`availableModels.map(m => m.fullId)`) as a potential fallback.
2. `resolveModelCandidate` warns on **any ref containing `/`** — the R8 'loud passthrough' trust-path warning for hand-asserted provider-qualified ids.

On OpenRouter, *every* catalog id contains `/`, so every catalog-enumerated ref triggers the warning — even though these refs come **from the catalog** and are validated by construction. The dedup set is per-process, and each crew worker is its own child process, so the warnings repeat per spawned agent.

## Fix

Thread a `{ fromCatalog?: boolean }` option from the auto-tail call site through `buildModelCandidates` into `resolveModelCandidate`. When set, the provider-qualified-ref warning is skipped. Behavior changes **only** for catalog-enumerated refs:

- ✅ hand-asserted refs (agent `model:` / `fallbackModels:` frontmatter, tool overrides) — warning unchanged
- ✅ no-catalog / no-match warnings — unchanged
- ✅ resolution results — byte-identical
- 🔇 catalog-enumerated auto-tail refs — no longer warn (false positive)

## Testing

- New regression test in `test/unit/runtime/model/model-budget-summary.test.ts`: catalog-enumerated refs via `buildModelCandidates(..., { fromCatalog: true })` emit zero passthrough warnings while a hand-asserted ref in the same process still warns exactly once.
- Full `test/unit/runtime/model/` suite: **159/159 pass**.
- `npm run typecheck`: clean.

## Verification note

Reproduced on 0.10.1 with a 352-model OpenRouter catalog; a review workflow with 3 child agents produced the full wall of warnings per child. After the patch, hand-declared fallback chains still warn (verified via the existing dedup tests).