### PR TITLE
fix(lazy-import): drop TDZ-unsafe module-level let cache

### DIFF
--- a/src/extension/cross-extension-rpc.ts
+++ b/src/extension/cross-extension-rpc.ts
@@ -5,17 +5,13 @@ import { withHmacVerification } from "./rpc-hmac.ts";
 // Lazy-loaded to avoid pulling team-tool.ts (and its entire runtime chain) into module load.
 import type { handleTeamTool as HandleTeamToolFn } from "./team-tool.ts";
 
-let _cachedHandleTeamTool: typeof HandleTeamToolFn | undefined;
 async function handleTeamTool(
 	params: Parameters<typeof HandleTeamToolFn>[0],
 	ctx: Parameters<typeof HandleTeamToolFn>[1],
 ): Promise<Awaited<ReturnType<typeof HandleTeamToolFn>>> {
-	if (!_cachedHandleTeamTool) {
-		// LAZY: avoid pulling team-tool.ts (and its entire runtime chain) into module load.
-		const mod = await import("./team-tool.ts");
-		_cachedHandleTeamTool = mod.handleTeamTool;
-	}
-	return _cachedHandleTeamTool(params, ctx);
+	// LAZY: avoid pulling team-tool.ts (and its entire runtime chain) into module load.
+	const mod = await import("./team-tool.ts");
+	return mod.handleTeamTool(params, ctx);
 }
 
 import { parseLiveControlRealtimeMessage, publishLiveControlRealtime } from "../runtime/live-session/live-control-realtime.ts";

--- a/src/extension/registration/observability.ts
+++ b/src/extension/registration/observability.ts
@@ -75,14 +75,10 @@ export interface ObservabilityDeps {
 	}>;
 }
 
-let _cachedOTLPExporter: OTLPExporterCtor | undefined;
 async function importOTLPExporter(): Promise<OTLPExporterCtor> {
-	if (!_cachedOTLPExporter) {
-		// LAZY: opt-in OTLP metric export — load only when otlp.enabled=true.
-		const mod = await import("../../observability/exporters/otlp-exporter.ts");
-		_cachedOTLPExporter = mod.OTLPExporter as unknown as OTLPExporterCtor;
-	}
-	return _cachedOTLPExporter;
+	// LAZY: opt-in OTLP metric export — load only when otlp.enabled=true.
+	const mod = await import("../../observability/exporters/otlp-exporter.ts");
+	return mod.OTLPExporter as unknown as OTLPExporterCtor;
 }
 
 /**

--- a/src/extension/registration/subagent-tools.ts
+++ b/src/extension/registration/subagent-tools.ts
@@ -6,17 +6,13 @@ import { withSessionId } from "../team-tool/context.ts";
 // Lazy-loaded: team-tool.ts pulls in entire runtime chain.
 import type { handleTeamTool as HandleTeamToolFn } from "../team-tool.ts";
 
-let _cachedHandleTeamTool: typeof HandleTeamToolFn | undefined;
 async function handleTeamTool(
 	params: Parameters<typeof HandleTeamToolFn>[0],
 	ctx: Parameters<typeof HandleTeamToolFn>[1],
 ): Promise<Awaited<ReturnType<typeof HandleTeamToolFn>>> {
-	if (!_cachedHandleTeamTool) {
-		// LAZY: team-tool.ts pulls in entire runtime chain.
-		const mod = await import("../team-tool.ts");
-		_cachedHandleTeamTool = mod.handleTeamTool;
-	}
-	return _cachedHandleTeamTool(params, ctx);
+	// LAZY: team-tool.ts pulls in entire runtime chain.
+	const mod = await import("../team-tool.ts");
+	return mod.handleTeamTool(params, ctx);
 }
 
 import { Text } from "@earendil-works/pi-tui";

--- a/src/extension/registration/team-tool.ts
+++ b/src/extension/registration/team-tool.ts
@@ -18,17 +18,13 @@ import { resolveRealContainedPath } from "../../utils/safe-paths.ts";
 // Team tool handler — lazy-loaded because team-tool.ts imports many modules
 import type { handleTeamTool as HandleTeamToolFn } from "../team-tool.ts";
 
-let _cachedHandleTeamTool: typeof HandleTeamToolFn | undefined;
 async function handleTeamTool(
 	params: Parameters<typeof HandleTeamToolFn>[0],
 	ctx: Parameters<typeof HandleTeamToolFn>[1],
 ): Promise<ReturnType<typeof HandleTeamToolFn>> {
-	if (!_cachedHandleTeamTool) {
-		// LAZY: team-tool.ts imports many modules — defer until first use.
-		const mod = await import("../team-tool.ts");
-		_cachedHandleTeamTool = mod.handleTeamTool;
-	}
-	return _cachedHandleTeamTool(params, ctx);
+	// LAZY: team-tool.ts imports many modules — defer until first use.
+	const mod = await import("../team-tool.ts");
+	return mod.handleTeamTool(params, ctx);
 }
 
 import { readCrewAgents } from "../../runtime/crew-agent-records.ts";

--- a/src/extension/registration/ui.ts
+++ b/src/extension/registration/ui.ts
@@ -27,15 +27,10 @@ import type { CrewWidgetState } from "../../ui/widget/index.ts";
 import { stopCrewWidget, updateCrewWidget } from "../../ui/widget/index.ts";
 import { logInternalError } from "../../utils/internal-error.ts";
 
-/** Cached live-run-sidebar constructor (lazy-loaded on first overlay open). */
-let _cachedLiveRunSidebar: typeof LiveRunSidebarType | undefined;
 async function importLiveRunSidebar(): Promise<typeof LiveRunSidebarType> {
-	if (!_cachedLiveRunSidebar) {
-		// LAZY: defer LiveRunSidebar import until the user opens a sidebar overlay.
-		const mod = await import("../../ui/live-run-sidebar.ts");
-		_cachedLiveRunSidebar = mod.LiveRunSidebar;
-	}
-	return _cachedLiveRunSidebar;
+	// LAZY: defer LiveRunSidebar import until the user opens a sidebar overlay.
+	const mod = await import("../../ui/live-run-sidebar.ts");
+	return mod.LiveRunSidebar;
 }
 
 /** Mutable state owned by register.ts. */

--- a/src/extension/registration/viewers.ts
+++ b/src/extension/registration/viewers.ts
@@ -8,17 +8,10 @@ import { asCrewTheme } from "../../ui/theme-adapter.ts";
 // Lazy-loaded: DurableTranscriptViewer is 658ms — only needed for /crew transcript command
 import type { DurableTranscriptViewer as DurableTranscriptViewerType } from "../../ui/transcript-viewer.ts";
 
-let _cachedViewer: typeof DurableTranscriptViewerType | undefined;
-let _viewerPromise: Promise<typeof DurableTranscriptViewerType> | undefined;
 async function getViewer(): Promise<typeof DurableTranscriptViewerType> {
-	if (_cachedViewer) return _cachedViewer;
-	if (!_viewerPromise) {
-		_viewerPromise = import("../../ui/transcript-viewer.ts").then((mod) => {
-			_cachedViewer = mod.DurableTranscriptViewer;
-			return mod.DurableTranscriptViewer;
-		});
-	}
-	return _viewerPromise;
+	// LAZY: DurableTranscriptViewer is 658ms — only needed for /crew transcript.
+	const mod = await import("../../ui/transcript-viewer.ts");
+	return mod.DurableTranscriptViewer;
 }
 
 export async function selectAgentTask(

--- a/src/extension/team-manager-command.ts
+++ b/src/extension/team-manager-command.ts
@@ -3,17 +3,13 @@ import { listRuns } from "./run-index.ts";
 // Lazy-loaded: team-tool.ts pulls in entire runtime chain.
 import type { handleTeamTool as HandleTeamToolFn } from "./team-tool.ts";
 
-let _cachedHandleTeamTool: typeof HandleTeamToolFn | undefined;
 async function handleTeamTool(
 	params: Parameters<typeof HandleTeamToolFn>[0],
 	ctx: Parameters<typeof HandleTeamToolFn>[1],
 ): Promise<Awaited<ReturnType<typeof HandleTeamToolFn>>> {
-	if (!_cachedHandleTeamTool) {
-		// LAZY: team-tool.ts pulls in the entire runtime chain.
-		const mod = await import("./team-tool.ts");
-		_cachedHandleTeamTool = mod.handleTeamTool;
-	}
-	return _cachedHandleTeamTool(params, ctx);
+	// LAZY: team-tool.ts pulls in the entire runtime chain.
+	const mod = await import("./team-tool.ts");
+	return mod.handleTeamTool(params, ctx);
 }
 
 import { isToolError, textFromToolResult } from "./tool-result.ts";

--- a/src/extension/team-tool.ts
+++ b/src/extension/team-tool.ts
@@ -23,14 +23,10 @@ import { listRecentRuns } from "./run-index.ts";
 import type { PiTeamsToolResult } from "./tool-result.ts";
 
 type ExecuteTeamRunFn = typeof _executeTeamRunFn;
-let _cachedExecuteTeamRun: ExecuteTeamRunFn | undefined;
 async function executeTeamRun(...args: Parameters<ExecuteTeamRunFn>): Promise<Awaited<ReturnType<ExecuteTeamRunFn>>> {
-	if (_cachedExecuteTeamRun === undefined) {
-		// LAZY: heavy runtime — defer 1.4s import cost until team run actually executes.
-		const mod = await import("../runtime/team-runner.ts");
-		_cachedExecuteTeamRun = mod.executeTeamRun;
-	}
-	return _cachedExecuteTeamRun(...args);
+	// LAZY: heavy runtime — defer 1.4s import cost until team run actually executes.
+	const mod = await import("../runtime/team-runner.ts");
+	return mod.executeTeamRun(...args);
 }
 
 import { directTeamAndWorkflowFromRun } from "../runtime/direct-run.ts";
@@ -44,14 +40,10 @@ import { buildParentContext, formatScoped, result, type TeamContext } from "./te
 import type { handleRun as _handleRunFn } from "./team-tool/run.ts";
 
 type HandleRunFn = typeof _handleRunFn;
-let _cachedHandleRun: HandleRunFn | undefined;
 async function handleRun(...args: Parameters<HandleRunFn>): Promise<Awaited<ReturnType<HandleRunFn>>> {
-	if (_cachedHandleRun === undefined) {
-		// LAZY: run.ts pulls in spawnBackgroundTeamRun + resolveCrewRuntime; also avoids jiti import race in child-process contexts.
-		const mod = await import("./team-tool/run.ts");
-		_cachedHandleRun = mod.handleRun;
-	}
-	return _cachedHandleRun(...args);
+	// LAZY: run.ts pulls in spawnBackgroundTeamRun + resolveCrewRuntime; also avoids jiti import race in child-process contexts.
+	const mod = await import("./team-tool/run.ts");
+	return mod.handleRun(...args);
 }
 
 import { t } from "../i18n.ts";

--- a/src/extension/team-tool/run.ts
+++ b/src/extension/team-tool/run.ts
@@ -18,14 +18,10 @@ import { logInternalError } from "../../utils/internal-error.ts";
 import { safeAbort } from "../../utils/safe-abort.ts";
 import { resolveRealContainedPath } from "../../utils/safe-paths.ts";
 
-let _cachedExecuteTeamRun: typeof ExecuteTeamRunFn | undefined;
 async function executeTeamRun(...args: Parameters<typeof ExecuteTeamRunFn>): Promise<Awaited<ReturnType<typeof ExecuteTeamRunFn>>> {
-	if (!_cachedExecuteTeamRun) {
-		// LAZY: heavy runtime — defer 1.4s import cost until team run actually executes.
-		const mod = await import("../../runtime/team-runner.ts");
-		_cachedExecuteTeamRun = mod.executeTeamRun;
-	}
-	return _cachedExecuteTeamRun(...args);
+	// LAZY: heavy runtime — defer 1.4s import cost until team run actually executes.
+	const mod = await import("../../runtime/team-runner.ts");
+	return mod.executeTeamRun(...args);
 }
 
 import { spawnBackgroundTeamRun } from "../../runtime/async-runner.ts";

--- a/src/runtime/background-runner.ts
+++ b/src/runtime/background-runner.ts
@@ -18,8 +18,6 @@ import { allWorkflows, discoverWorkflows } from "../workflows/discover-workflows
 import { primePeerDep } from "./peer-dep.ts";
 import type { executeTeamRun as ExecuteTeamRunFn } from "./team-runner.ts";
 
-let _cachedExecuteTeamRun: typeof ExecuteTeamRunFn | undefined;
-
 /** Maximum runtime for a single background run before the watchdog force-aborts
  *  it. Prevents zombie background-runner processes when a team run hangs forever
  *  (e.g. a hung child Pi process, a stuck lock, or a test that spawns a run
@@ -33,16 +31,13 @@ const MAX_BACKGROUND_RUN_MS = (() => {
 	return Number.isFinite(env) && env > 0 ? env : 2 * 60 * 60 * 1000;
 })();
 async function executeTeamRun(...args: Parameters<typeof ExecuteTeamRunFn>): Promise<Awaited<ReturnType<typeof ExecuteTeamRunFn>>> {
-	if (!_cachedExecuteTeamRun) {
-		// FIX (split-scope install): prime the ESM peer dep BEFORE team-runner is
-		// imported, so its transitive skill-instructions.ts can read getAgentDir()
-		// from the primed cache instead of crashing on `Cannot find module`.
-		await primePeerDep().catch(() => undefined);
-		// LAZY: avoid pulling team-runner into background-runner at module load time.
-		const mod = await import("./team-runner.ts");
-		_cachedExecuteTeamRun = mod.executeTeamRun;
-	}
-	return _cachedExecuteTeamRun(...args);
+	// FIX (split-scope install): prime the ESM peer dep BEFORE team-runner is
+	// imported, so its transitive skill-instructions.ts can read getAgentDir()
+	// from the primed cache instead of crashing on `Cannot find module`.
+	await primePeerDep().catch(() => undefined);
+	// LAZY: avoid pulling team-runner into background-runner at module load time.
+	const mod = await import("./team-runner.ts");
+	return mod.executeTeamRun(...args);
 }
 
 import { logInternalError } from "../utils/internal-error.ts";

--- a/src/ui/run-action-dispatcher.ts
+++ b/src/ui/run-action-dispatcher.ts
@@ -3,17 +3,13 @@ import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { handleTeamTool as HandleTeamToolFn } from "../extension/team-tool.ts";
 import type { MetricRegistry } from "../observability/metric-registry.ts";
 
-let _cachedHandleTeamTool: typeof HandleTeamToolFn | undefined;
 async function handleTeamTool(
 	params: Parameters<typeof HandleTeamToolFn>[0],
 	ctx: Parameters<typeof HandleTeamToolFn>[1],
 ): Promise<Awaited<ReturnType<typeof HandleTeamToolFn>>> {
-	if (!_cachedHandleTeamTool) {
-		// LAZY: avoid pulling team-tool.ts (and its entire runtime chain) into module load.
-		const mod = await import("../extension/team-tool.ts");
-		_cachedHandleTeamTool = mod.handleTeamTool;
-	}
-	return _cachedHandleTeamTool(params, ctx);
+	// LAZY: avoid pulling team-tool.ts (and its entire runtime chain) into module load.
+	const mod = await import("../extension/team-tool.ts");
+	return mod.handleTeamTool(params, ctx);
 }
 
 import { isToolError, textFromToolResult } from "../extension/tool-result.ts";

--- a/test/unit/lazy-import-tdz.test.ts
+++ b/test/unit/lazy-import-tdz.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Regression guard: a lazy-import wrapper must not cache the imported symbol
+ * in a module-level `let`.
+ *
+ * `let` bindings are not hoisted, function declarations are. Under a cyclic
+ * import the cycle partner can call the hoisted wrapper while the declaring
+ * module body is still pending, so the read hits the temporal dead zone and
+ * the process dies with `ReferenceError: Cannot access '_cachedX' before
+ * initialization`. Reported in the field on 0.2.20 for
+ * `src/extension/team-tool.ts` (`_cachedHandleRun`), whose cycle partner
+ * `src/extension/team-tool/dispatch/run.ts` imports `handleRun` back from it.
+ *
+ * The cache is redundant: the module loader already caches `import()`.
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { pathToFileURL } from "node:url";
+
+const SRC_DIR = join(import.meta.dirname, "..", "..", "src");
+
+/**
+ * Sites whose module-level cache is read by something other than the lazy
+ * wrapper, so dropping it would change behavior: `commands/shared.ts` has the
+ * `__test__setHandleTeamTool` seam, `crash-recovery-cache.ts` has a sync
+ * purge-if-loaded probe.
+ */
+const STATEFUL_BY_DESIGN: Record<string, true> = {
+	"extension/registration/commands/shared.ts": true,
+	"extension/registration/crash-recovery-cache.ts": true,
+};
+
+function listTsFiles(dir: string, prefix = ""): string[] {
+	const out: string[] = [];
+	for (const entry of readdirSync(dir)) {
+		const full = join(dir, entry);
+		if (statSync(full).isDirectory()) out.push(...listTsFiles(full, `${prefix}${entry}/`));
+		else if (entry.endsWith(".ts")) out.push(`${prefix}${entry}`);
+	}
+	return out;
+}
+
+describe("lazy-import TDZ", () => {
+	it("a module-level `let` cache crashes when a cycle partner calls the wrapper", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "pi-crew-tdz-"));
+		try {
+			writeFileSync(join(dir, "impl.mjs"), `export function run() { return "ran"; }\n`);
+			writeFileSync(join(dir, "partner.mjs"), `import { run } from "./facade.mjs";\nawait run();\n`);
+			// TEST SEAM: fixtures are written at runtime, so the specifier cannot be static.
+			writeFileSync(
+				join(dir, "facade.mjs"),
+				`import "./partner.mjs";\nlet _cachedRun;\nexport async function run() {\n\tif (_cachedRun === undefined) _cachedRun = (await import("./impl.mjs")).run;\n\treturn _cachedRun();\n}\n`,
+			);
+			await assert.rejects(
+				() => import(pathToFileURL(join(dir, "facade.mjs")).href),
+				/Cannot access '_cachedRun' before initialization/,
+			);
+
+			// Same cycle without the cache: the loader caches `import()` itself.
+			writeFileSync(
+				join(dir, "ok-partner.mjs"),
+				`import { run } from "./ok.mjs";\nif ((await run()) !== "ran") throw new Error("wrong result");\n`,
+			);
+			writeFileSync(
+				join(dir, "ok.mjs"),
+				`import "./ok-partner.mjs";\nexport async function run() {\n\treturn (await import("./impl.mjs")).run();\n}\n`,
+			);
+			await import(pathToFileURL(join(dir, "ok.mjs")).href);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("no lazy wrapper in src caches an imported symbol in a module-level `let`", () => {
+		const offenders: string[] = [];
+		for (const file of listTsFiles(SRC_DIR)) {
+			if (STATEFUL_BY_DESIGN[file]) continue;
+			const content = readFileSync(join(SRC_DIR, file), "utf8");
+			if (!content.includes("import(")) continue;
+			for (const [, name] of content.matchAll(/^let (\w+)[^\n]*;$/gm)) {
+				if (new RegExp(`\\b${name} = (mod\\.\\w+|\\w*mod\\b)`).test(content)) offenders.push(`${file}: ${name}`);
+			}
+		}
+		assert.deepEqual(offenders, [], `TDZ-unsafe lazy caches under cyclic imports:\n${offenders.join("\n")}`);
+	});
+});


### PR DESCRIPTION
## Problem

Every lazy-import wrapper in `src/` cached the imported symbol in a
module-level `let`:

```ts
let _cachedHandleRun: HandleRunFn | undefined;
async function handleRun(...args: Parameters<HandleRunFn>) {
	if (_cachedHandleRun === undefined) {
		const mod = await import("./team-tool/run.ts");
		_cachedHandleRun = mod.handleRun;
	}
	return _cachedHandleRun(...args);
}
```

Function declarations hoist. `let` bindings do not. Under a cyclic import
the cycle partner can call the hoisted wrapper while the declaring module
body is still pending, so the read hits the temporal dead zone:

```
ReferenceError: Cannot access '_cachedHandleRun' before initialization
    at handleRun (.../src/extension/team-tool.ts:90)
```

That kills the whole Pi session. `src/extension/team-tool.ts`
has the cycle: it imports `./team-tool/api.ts` and friends above the cache
declaration, and `src/extension/team-tool/dispatch/run.ts` imports
`handleRun` back from `../../team-tool.ts`. Seen in the field on 0.2.20.

Minimal reproduction of the mechanism (plain Node 22+, no pi-crew):

```
$ node repro/a.mjs
ReferenceError: Cannot access '_cachedHandleRun' before initialization
    at handleRun (file:///.../repro/a.mjs:6:2)
    at file:///.../repro/b.mjs:4:7
```

`a.mjs` is the wrapper above, `b.mjs` is the cycle partner that calls it
during evaluation, `run.mjs` is the lazily imported module. The same test
is committed as `test/unit/lazy-import-tdz.test.ts`.

## Fix

The cache was redundant. The module loader already caches `import()`, so
the wrapper can call through the namespace object and keep the same
single-load behavior and the same `// LAZY:` markers:

```ts
async function handleRun(...args: Parameters<HandleRunFn>) {
	// LAZY: run.ts pulls in spawnBackgroundTeamRun + resolveCrewRuntime; also avoids jiti import race in child-process contexts.
	const mod = await import("./team-tool/run.ts");
	return mod.handleRun(...args);
}
```

Applied to all 12 instances of the pattern, in 11 files:

- `src/extension/team-tool.ts` (`_cachedExecuteTeamRun`, `_cachedHandleRun`)
- `src/extension/team-tool/run.ts` (`_cachedExecuteTeamRun`)
- `src/extension/cross-extension-rpc.ts`
- `src/extension/team-manager-command.ts`
- `src/extension/registration/team-tool.ts`
- `src/extension/registration/subagent-tools.ts`
- `src/extension/registration/observability.ts`
- `src/extension/registration/ui.ts`
- `src/extension/registration/viewers.ts` (also drops the `_viewerPromise`
  de-dupe, which `import()` does natively)
- `src/runtime/background-runner.ts` (keeps the `primePeerDep()` call
  before the import; `primePeerDep` is already memoized)
- `src/ui/run-action-dispatcher.ts`

Two sites keep their module-level state and are unchanged, because
something other than the wrapper reads it:

- `src/extension/registration/commands/shared.ts` — the
  `__test__setHandleTeamTool` seam writes the variable.
- `src/extension/registration/crash-recovery-cache.ts` —
  `purgeStaleActiveRunIndexSyncIfLoaded` reads it synchronously.

Both are listed in `STATEFUL_BY_DESIGN` in the new test. If they ever hit
the same crash they need a different shape, so I left that call to you.

`var` also removes the crash by hoisting, but Biome's recommended
`style/noVar` rejects it, and deleting the cache is the smaller change.

## Checks

```
$ node scripts/test-runner.mjs --test-concurrency=1 --test-timeout=60000 test/unit/lazy-import-tdz.test.ts
▶ lazy-import TDZ
  ✔ a module-level `let` cache crashes when a cycle partner calls the wrapper
  ✔ no lazy wrapper in src caches an imported symbol in a module-level `let`
ℹ pass 2  ℹ fail 0

$ npx tsc --noEmit           # clean
$ node scripts/check-lazy-imports.mjs
All dynamic imports have `// LAZY:` marker.
$ npx biome check <touched files>   # clean
```

The scan test fails on the current `main` and lists all 12 sites.

`dist/index.mjs` is untouched; it looks like it is rebuilt on release.

## Related, not duplicates

- #10 / #17 — `background-runner` `ReferenceError` on process exit: the
  `exit` handler read a `let manifest` declared inside `main()`. Same
  TDZ family, different variable, already fixed.
- #28 — jiti namespace race in `crew-init.ts`
  (`Cannot read properties of undefined (reading 'parse')`). Different
  failure, different fix.
